### PR TITLE
Tidy up config and query building

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/person/GetPersonByIdQueryBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/person/GetPersonByIdQueryBuilder.kt
@@ -1,0 +1,36 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.repository.person
+
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.JoinType
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.SqlQueryBuilder
+
+class GetPersonByIdQueryBuilder : SqlQueryBuilder {
+  constructor(id: Long) : super("allied_mdss_test_20250714014447.person", "p") {
+    this.addFields(
+      listOf(
+        "p.person_id",
+        "p.person_name",
+        "pdw.u_id_nomis",
+        "pdws.u_dob",
+        "csm.zip",
+        "csm.city",
+        "csm.street",
+      ),
+    )
+      .addJoin(
+        "serco_servicenow_test.x_serg2_ems_csm_profile_device_wearer pdw",
+        "p.person_name = pdw.u_id_device_wearer",
+        JoinType.INNER,
+      )
+      .addJoin(
+        "serco_servicenow_test.csm_consumer csm",
+        "pdw.consumer__value = csm.sys_id",
+        JoinType.INNER,
+      )
+      .addJoin(
+        "serco_servicenow_test.x_serg2_ems_csm_profile_sensitive pdws",
+        "csm.sys_id = pdws.consumer__value",
+        JoinType.INNER,
+      )
+      .addFilter("p.person_id", id)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/person/PersonRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/person/PersonRepository.kt
@@ -70,37 +70,8 @@ class PersonRepository(
   }
 
   fun getPersonById(id: Long): AthenaPersonDto {
-    val queryExecutionId = athenaClient.getQueryExecutionId(
-      SqlQueryBuilder("allied_mdss_test_20250714014447.person", "p")
-        .addFields(
-          listOf(
-            "p.person_id",
-            "p.person_name",
-            "pdw.u_id_nomis",
-            "pdws.u_dob",
-            "csm.zip",
-            "csm.city",
-            "csm.street",
-          ),
-        )
-        .addJoin(
-          "serco_servicenow_test.x_serg2_ems_csm_profile_device_wearer pdw",
-          "p.person_name = pdw.u_id_device_wearer",
-          JoinType.INNER,
-        )
-        .addJoin(
-          "serco_servicenow_test.csm_consumer csm",
-          "pdw.consumer__value = csm.sys_id",
-          JoinType.INNER,
-        )
-        .addJoin(
-          "serco_servicenow_test.x_serg2_ems_csm_profile_sensitive pdws",
-          "csm.sys_id = pdws.consumer__value",
-          JoinType.INNER,
-        )
-        .addFilter("p.person_id", id)
-        .build(),
-    )
+    val query = GetPersonByIdQueryBuilder(id).build()
+    val queryExecutionId = athenaClient.getQueryExecutionId(query)
     val queryResult = athenaClient.getQueryResult(queryExecutionId)
     val persons = AthenaHelper.Companion.mapTo<AthenaPersonDto>(queryResult)
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -7,13 +7,8 @@ hmpps.sqs:
 
 services:
   hmpps-auth:
-    url: "http://localhost:8090/auth"
+    url: ${HMPPS_AUTH_URL:http://localhost:8090/auth}
     mfa: false
-  athena:
-    # Values for connecting to TEST Athena instance
-    output: s3://emds-test-athena-query-results-20240923095933297100000013
-  athena-roles:
-    general: fakeIAM
 
 spring:
   jpa:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -76,4 +76,4 @@ aws:
     role: ${ATHENA_GENERAL_IAM_ROLE}
 
 datastore:
-  output-bucket-arn: ${ATHENA_OUTPUT_BUCKET:-s3://emds-dev-athena-query-results-20240917144028307600000004}
+  output-bucket-arn: ${ATHENA_OUTPUT_BUCKET}


### PR DESCRIPTION
Updated the application-local properties to allow `HMPPS_AUTH_URL` to be set with an environment variable e.g. with the development endpoint.

There were two different output buckets specified in different places. I've removed the hard-coded values in favour of setting it in the environment and removed some unused config values.

Small refactor of the `PersonsRepsoitory` to move the query out of the file. No real reason here, just thought it would be a bit tidier to separate them.