### PR TITLE
Configure logging for the datastore client

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -21,3 +21,14 @@ AWS requests are differentiated by the `X-Amz-Target` header.
 </logger>
 ```
 
+## Athena Queries
+
+By default the application is configured to with a log level of `DEBUG` for any class path within 
+`uk.gov.justice.digital.hmpps`. To change the log level of the Athena query logging, the following snippet can be added 
+to `logback-spring.xml`.
+
+```xml
+<logger name="uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.client.EmDatastoreClient" additivity="false" level="INFO">
+  <appender-ref ref="consoleAppender"/>
+</logger>
+```

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/client/EmDatastoreClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/client/EmDatastoreClient.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.client
 
+import org.slf4j.LoggerFactory
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Component
@@ -25,6 +26,8 @@ class EmDatastoreClient(
   val athenaClient: AthenaClient,
   val properties: DatastoreProperties,
 ) : EmDatastoreClientInterface {
+
+  private val log = LoggerFactory.getLogger(this::class.java)
 
   override fun getQueryResult(athenaQuery: AthenaQuery): ResultSet {
     val queryExecutionId: String = submitAthenaQuery(athenaClient, athenaQuery)
@@ -71,6 +74,8 @@ class EmDatastoreClient(
 
       startQueryExecutionRequest.resultConfiguration(resultConfiguration)
 
+      log.debug("Starting query: {}", query)
+
       val startQueryExecutionResponse = athenaClient.startQueryExecution(startQueryExecutionRequest.build())
 
       return startQueryExecutionResponse.queryExecutionId()
@@ -103,7 +108,7 @@ class EmDatastoreClient(
         // Sleep an amount of time before retrying again.
         Thread.sleep(properties.retryIntervalMs)
       }
-      println("The current status is: $queryState")
+      log.debug("Query execution id $queryExecutionId has status: $queryState")
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/model/athena/AthenaQuery.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/model/athena/AthenaQuery.kt
@@ -5,4 +5,8 @@ import java.io.Serializable
 class AthenaQuery(
   val queryString: String,
   val parameters: Array<String>,
-) : Serializable
+) : Serializable {
+  override fun toString(): String {
+    return this.queryString
+  }
+}


### PR DESCRIPTION
Replaced the current logging within the `EmDatastoreClient` with the builtin logger. This enables configuration of the log level for the `EmDatastoreClient`. Currently the log level is set to `DEBUG` but this can be changed as the need arises.

Previously when checking the status of a query execution, a log message similar to `The current status is: RUNNING` was output. This is somewhat useful when debugging locally but isn't likely to be useful when multiple clients are initiating queries in a deployed environment due to the lack of context in the message. This has been updated to include the query execution id so will be similar to `Query execution id ccbbf440-fbe8-486a-993b-7295c23c4598 has status: RUNNING`

Added additional logging of the query string sent to Athena as a development aid. This logs the query without the query execution parameters.