### PR TITLE
Make MethodArgumentTypeMismatchException error message slightly nicer

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/config/ElectronicMonitoringCrimeMatchingApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/config/ElectronicMonitoringCrimeMatchingApiExceptionHandler.kt
@@ -37,8 +37,8 @@ class ElectronicMonitoringCrimeMatchingApiExceptionHandler {
     .body(
       ErrorResponse(
         status = BAD_REQUEST,
-        userMessage = "The provided value \"${e.value}\" is the incorrect type for the ${e.name} parameter.",
-        developerMessage = "The provided value \"${e.value}\" is the incorrect type for the ${e.name} parameter.",
+        userMessage = "The provided value '${e.value}' is the incorrect type for the '${e.name}' parameter.",
+        developerMessage = "The provided value '${e.value}' is the incorrect type for the '${e.name}' parameter.",
       ),
     ).also { log.info("MethodArgumentTypeMismatchException: {}", e.message) }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/resource/DeviceActivationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/resource/DeviceActivationControllerTest.kt
@@ -43,8 +43,8 @@ class DeviceActivationControllerTest : IntegrationTestBase() {
       assertThat(result).isEqualTo(
         ErrorResponse(
           status = BAD_REQUEST,
-          userMessage = "The provided value \"abc\" is the incorrect type for the deviceActivationId parameter.",
-          developerMessage = "The provided value \"abc\" is the incorrect type for the deviceActivationId parameter.",
+          userMessage = "The provided value 'abc' is the incorrect type for the 'deviceActivationId' parameter.",
+          developerMessage = "The provided value 'abc' is the incorrect type for the 'deviceActivationId' parameter.",
         ),
       )
     }
@@ -238,8 +238,8 @@ class DeviceActivationControllerTest : IntegrationTestBase() {
       assertThat(result).isEqualTo(
         ErrorResponse(
           status = BAD_REQUEST,
-          userMessage = "The provided value \"abc\" is the incorrect type for the deviceActivationId parameter.",
-          developerMessage = "The provided value \"abc\" is the incorrect type for the deviceActivationId parameter.",
+          userMessage = "The provided value 'abc' is the incorrect type for the 'deviceActivationId' parameter.",
+          developerMessage = "The provided value 'abc' is the incorrect type for the 'deviceActivationId' parameter.",
         ),
       )
     }
@@ -353,8 +353,8 @@ class DeviceActivationControllerTest : IntegrationTestBase() {
       assertThat(result).isEqualTo(
         ErrorResponse(
           status = BAD_REQUEST,
-          userMessage = "The provided value \"abc\" is the incorrect type for the geolocationMechanism parameter.",
-          developerMessage = "The provided value \"abc\" is the incorrect type for the geolocationMechanism parameter.",
+          userMessage = "The provided value 'abc' is the incorrect type for the 'geolocationMechanism' parameter.",
+          developerMessage = "The provided value 'abc' is the incorrect type for the 'geolocationMechanism' parameter.",
         ),
       )
     }
@@ -381,8 +381,8 @@ class DeviceActivationControllerTest : IntegrationTestBase() {
       assertThat(result).isEqualTo(
         ErrorResponse(
           status = BAD_REQUEST,
-          userMessage = "The provided value \"abc\" is the incorrect type for the from parameter.",
-          developerMessage = "The provided value \"abc\" is the incorrect type for the from parameter.",
+          userMessage = "The provided value 'abc' is the incorrect type for the 'from' parameter.",
+          developerMessage = "The provided value 'abc' is the incorrect type for the 'from' parameter.",
         ),
       )
     }
@@ -409,8 +409,8 @@ class DeviceActivationControllerTest : IntegrationTestBase() {
       assertThat(result).isEqualTo(
         ErrorResponse(
           status = BAD_REQUEST,
-          userMessage = "The provided value \"abc\" is the incorrect type for the to parameter.",
-          developerMessage = "The provided value \"abc\" is the incorrect type for the to parameter.",
+          userMessage = "The provided value 'abc' is the incorrect type for the 'to' parameter.",
+          developerMessage = "The provided value 'abc' is the incorrect type for the 'to' parameter.",
         ),
       )
     }


### PR DESCRIPTION
The escaped quotes weren't really useful and look a bit weird:

e.g. `The provided value \"abc\" is the incorrect type for the deviceActivationId parameter.`

So I've replaced them with single quotes and added single quotes around the parameter name to make it clearer.
