### PR TITLE
Update all responses to use the ResponseDto

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/dto/ResponseDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/dto/ResponseDto.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.dto
+
+data class ResponseDto<T>(
+  val data: T,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/resource/deviceActivation/DeviceActivationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/resource/deviceActivation/DeviceActivationController.kt
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestMethod
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.dto.DeviceActivationDto
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.dto.PositionDto
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.dto.ResponseDto
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.entity.GeolocationMechanism
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.service.deviceActivation.DeviceActivationService
 import java.time.ZonedDateTime
@@ -33,11 +34,13 @@ class DeviceActivationController(
   )
   fun getDeviceActivation(
     @PathVariable deviceActivationId: Long,
-  ): ResponseEntity<DeviceActivationDto> {
+  ): ResponseEntity<ResponseDto<DeviceActivationDto>> {
     val deviceActivation = deviceActivationService.getDeviceActivation(deviceActivationId)
 
     return ResponseEntity.ok(
-      DeviceActivationDto(deviceActivation),
+      ResponseDto(
+        DeviceActivationDto(deviceActivation),
+      ),
     )
   }
 
@@ -57,7 +60,7 @@ class DeviceActivationController(
     geolocationMechanism: GeolocationMechanism? = null,
     from: ZonedDateTime? = null,
     to: ZonedDateTime? = null,
-  ): ResponseEntity<List<PositionDto>> {
+  ): ResponseEntity<ResponseDto<List<PositionDto>>> {
     val positions = deviceActivationService.getDeviceActivationPositions(
       deviceActivationId,
       geolocationMechanism,
@@ -66,7 +69,9 @@ class DeviceActivationController(
     )
 
     return ResponseEntity.ok(
-      positions.map { PositionDto(it) },
+      ResponseDto(
+        positions.map { PositionDto(it) },
+      ),
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/resource/person/PersonController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/resource/person/PersonController.kt
@@ -14,6 +14,7 @@ import org.springframework.web.server.ResponseStatusException
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.dto.PagedResponseDto
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.dto.PersonDto
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.dto.PersonsQueryCriteria
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.dto.ResponseDto
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.service.person.PersonService
 
 @RestController
@@ -58,9 +59,13 @@ class PersonController(
   )
   fun getPerson(
     @PathVariable personId: Long,
-  ): ResponseEntity<PersonDto> {
+  ): ResponseEntity<ResponseDto<PersonDto>> {
     val person = personService.getPerson(personId)
 
-    return ResponseEntity.ok(PersonDto(person))
+    return ResponseEntity.ok(
+      ResponseDto(
+        PersonDto(person),
+      ),
+    )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/resource/DeviceActivationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/resource/DeviceActivationControllerTest.kt
@@ -8,9 +8,9 @@ import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.reactive.server.expectBody
-import org.springframework.test.web.reactive.server.expectBodyList
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.dto.DeviceActivationDto
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.dto.PositionDto
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.dto.ResponseDto
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.integration.IntegrationTestBase
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
@@ -81,11 +81,11 @@ class DeviceActivationControllerTest : IntegrationTestBase() {
         .exchange()
         .expectStatus()
         .isOk
-        .expectBody<DeviceActivationDto>()
+        .expectBody<ResponseDto<DeviceActivationDto>>()
         .returnResult()
         .responseBody!!
 
-      assertThat(result).isEqualTo(
+      assertThat(result.data).isEqualTo(
         DeviceActivationDto(
           deviceActivationId = 12345,
           deviceId = 54321,
@@ -114,11 +114,11 @@ class DeviceActivationControllerTest : IntegrationTestBase() {
         .exchange()
         .expectStatus()
         .isOk
-        .expectBody<DeviceActivationDto>()
+        .expectBody<ResponseDto<DeviceActivationDto>>()
         .returnResult()
         .responseBody!!
 
-      assertThat(result).isEqualTo(
+      assertThat(result.data).isEqualTo(
         DeviceActivationDto(
           deviceActivationId = 12345,
           deviceId = 54321,
@@ -259,11 +259,11 @@ class DeviceActivationControllerTest : IntegrationTestBase() {
         .exchange()
         .expectStatus()
         .isOk
-        .expectBodyList<PositionDto>()
+        .expectBody<ResponseDto<List<PositionDto>>>()
         .returnResult()
         .responseBody!!
 
-      assertThat(result).isEmpty()
+      assertThat(result.data).isEmpty()
     }
 
     @Test
@@ -281,11 +281,11 @@ class DeviceActivationControllerTest : IntegrationTestBase() {
         .exchange()
         .expectStatus()
         .isOk
-        .expectBodyList<PositionDto>()
+        .expectBody<ResponseDto<List<PositionDto>>>()
         .returnResult()
         .responseBody!!
 
-      assertThat(result).isEqualTo(
+      assertThat(result.data).isEqualTo(
         listOf(
           PositionDto(
             positionId = 1,
@@ -430,7 +430,7 @@ class DeviceActivationControllerTest : IntegrationTestBase() {
         .exchange()
         .expectStatus()
         .isOk
-        .expectBodyList<PositionDto>()
+        .expectBody<ResponseDto<List<PositionDto>>>()
         .returnResult()
         .responseBody!!
 
@@ -456,7 +456,7 @@ class DeviceActivationControllerTest : IntegrationTestBase() {
         .exchange()
         .expectStatus()
         .isOk
-        .expectBodyList<PositionDto>()
+        .expectBody<ResponseDto<List<PositionDto>>>()
         .returnResult()
         .responseBody!!
 
@@ -482,7 +482,7 @@ class DeviceActivationControllerTest : IntegrationTestBase() {
         .exchange()
         .expectStatus()
         .isOk
-        .expectBodyList<PositionDto>()
+        .expectBody<ResponseDto<List<PositionDto>>>()
         .returnResult()
         .responseBody!!
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/resource/PersonControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/resource/PersonControllerTest.kt
@@ -9,6 +9,7 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.reactive.server.expectBody
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.dto.PagedResponseDto
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.dto.PersonDto
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.dto.ResponseDto
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.integration.IntegrationTestBase
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
@@ -135,16 +136,22 @@ class PersonControllerTest : IntegrationTestBase() {
         .exchange()
         .expectStatus()
         .isOk
-        .expectBody(PersonDto::class.java)
+        .expectBody<ResponseDto<PersonDto>>()
         .returnResult()
         .responseBody!!
 
-      assertThat(result.personId).isEqualTo(1)
-      assertThat(result.nomisId).isEqualTo("nomis_id")
-      assertThat(result.name).isEqualTo("person_name")
-      assertThat(result.address).isEqualTo("street city zip")
-      assertThat(result.dateOfBirth).isEqualTo("2000-05-29")
-      assertThat(result.deviceActivations).isNotNull().isEmpty()
+      assertThat(result.data).isEqualTo(
+        PersonDto(
+          personId = 1,
+          name = "person_name",
+          nomisId = "nomis_id",
+          pncRef = "",
+          dateOfBirth = "2000-05-29",
+          probationPractitioner = "",
+          address = "street city zip",
+          deviceActivations = listOf(),
+        ),
+      )
     }
 
     @Test


### PR DESCRIPTION
We built the UI on the premise that all response would be of the format:

```json
{
    "data": ...
}
```