### PR TITLE
ACR-237 - Caching bug

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/config/caching/PostgresCache.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/config/caching/PostgresCache.kt
@@ -29,6 +29,7 @@ class PostgresCache(
 
     return entry?.let {
       if (it.createdAt.plus(ttl).isBefore(LocalDateTime.now())) {
+        repository.delete(entry)
         return null
       }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/config/caching/PostgresCacheManager.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/config/caching/PostgresCacheManager.kt
@@ -18,7 +18,7 @@ class PostgresCacheManager(
 ) : CacheManager {
 
   private val caches = ConcurrentHashMap<String, Cache>()
-  val defaultTtl: Duration = Duration.ofMinutes(10)
+  val defaultTtl: Duration = Duration.ofHours(6)
 
   override fun getCache(name: String): Cache? = caches.computeIfAbsent(name) {
     val cacheConfig = properties.configs[it]

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/config/caching/PostgresCacheTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/config/caching/PostgresCacheTest.kt
@@ -53,7 +53,7 @@ class PostgresCacheTest {
     }
 
     @Test
-    fun `get should return null for an expired entry`() {
+    fun `get should return null for an expired entry and remove the existing entry`() {
       whenever(
         repository.findByCacheNameAndCacheKey(any(), any()),
       ).thenReturn(expiredCacheEntry)
@@ -61,6 +61,7 @@ class PostgresCacheTest {
       val retrievedValue = cache.get("expired", String::class.java)
 
       assertThat(retrievedValue).isNull()
+      verify(repository, times(1)).delete(expiredCacheEntry)
     }
 
     @Test


### PR DESCRIPTION
Caching logic was failing due to expired entries remaining in the cache, this resolves the error by removing expired cache values if found on retrieval.