### PR TITLE
Specify workgroup in athena queries

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -13,6 +13,7 @@ generic-service:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: "applicationinsights.dev.json"
     HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
     ATHENA_OUTPUT_BUCKET: "s3://emds-dev-athena-query-results-20240917144028307600000004"
+    ATHENA_WORKGROUP: "800964199911-default"
     MFA_REQUIRED: "false"
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -13,6 +13,7 @@ generic-service:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: "applicationinsights.dev.json"
     HMPPS_AUTH_URL: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth"
     ATHENA_OUTPUT_BUCKET: "s3://emds-test-athena-query-results-20240923095933297100000013"
+    ATHENA_WORKGROUP: "placeholder"
     MFA_REQUIRED: "false"
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -10,6 +10,7 @@ generic-service:
   env:
     HMPPS_AUTH_URL: "https://sign-in.hmpps.service.justice.gov.uk/auth"
     ATHENA_OUTPUT_BUCKET: "placeholder"
+    ATHENA_WORKGROUP: "placeholder"
     MFA_REQUIRED: "false"
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/client/EmDatastoreClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/client/EmDatastoreClient.kt
@@ -67,6 +67,7 @@ class EmDatastoreClient(
       var startQueryExecutionRequest = StartQueryExecutionRequest.builder()
         .queryString(query.queryString)
         .queryExecutionContext(queryExecutionContext)
+        .workGroup(properties.workgroup)
 
       if (query.parameters.isNotEmpty()) {
         startQueryExecutionRequest.executionParameters(*query.parameters)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/config/datastore/DatastoreProperties.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/config/datastore/DatastoreProperties.kt
@@ -8,4 +8,5 @@ data class DatastoreProperties(
   val mdssDatabase: String,
   val outputBucketArn: String,
   val retryIntervalMs: Long = 1000,
+  val workgroup: String,
 )

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -87,6 +87,7 @@ datastore:
   fms-database: ${FMS_DATABASE:serco_fms_dev}
   mdss-database: ${MDSS_DATABASE:allied_mdss_dev}
   output-bucket-arn: ${ATHENA_OUTPUT_BUCKET}
+  workgroup: ${ATHENA_WORKGROUP}
 
 email-ingestion:
   valid-emails:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/wiremock/AwsMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/wiremock/AwsMockServer.kt
@@ -67,7 +67,7 @@ class AwsMockServer : WireMockServer(WIREMOCK_CONFIG) {
         urlPathEqualTo("/"),
       ).withHeader("X-Amz-Target", equalTo("AmazonAthena.StartQueryExecution"))
         .withRequestBody(
-          matchingJsonPath("$.WorkGroup", equalTo("default")),
+          matchingJsonPath("$.WorkGroup", equalTo("test-workgroup")),
         )
         .willReturn(
           aResponse()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/wiremock/AwsMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/wiremock/AwsMockServer.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.integr
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.equalTo
+import com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath
 import com.github.tomakehurst.wiremock.client.WireMock.post
 import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
 import com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching
@@ -65,6 +66,9 @@ class AwsMockServer : WireMockServer(WIREMOCK_CONFIG) {
       post(
         urlPathEqualTo("/"),
       ).withHeader("X-Amz-Target", equalTo("AmazonAthena.StartQueryExecution"))
+        .withRequestBody(
+          matchingJsonPath("$.WorkGroup", equalTo("default")),
+        )
         .willReturn(
           aResponse()
             .withHeader("Content-Type", "application/json")

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -53,6 +53,7 @@ spring:
 datastore:
   output-bucket-arn: test-output-bucket
   retry-interval-ms: 10
+  workgroup: default
 
 notify:
   enabled: false

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -53,7 +53,7 @@ spring:
 datastore:
   output-bucket-arn: test-output-bucket
   retry-interval-ms: 10
-  workgroup: default
+  workgroup: test-workgroup
 
 notify:
   enabled: false


### PR DESCRIPTION
- Data Store need us to use a specific workgroup rather than the default workgroup
- This will be environment specific
- Added workgroup to the datastore configuration object
- Updated wiremock stubs to match the workgroup property to ensure we're sending a correct workgroup