### PR TITLE
Receive additional properties from the crime matching algorithm

### DIFF
--- a/docs/model.mmd
+++ b/docs/model.mmd
@@ -121,5 +121,5 @@ erDiagram
         double longitude
         datetime capturedDateTime
         string sequenceLabel
-        int confidenceCircle
+        int precision
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/dto/CrimeMatchingResultDeviceWearerRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/dto/CrimeMatchingResultDeviceWearerRequest.kt
@@ -3,16 +3,29 @@ package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.dto
 import jakarta.validation.Valid
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
+import java.time.LocalDateTime
 
 data class CrimeMatchingResultDeviceWearerRequest(
+  @field:NotBlank(message = "Address is required")
+  val address: String,
+
+  @field:NotNull(message = "Date of birth is required")
+  val dateOfBirth: LocalDateTime,
+
   @field:NotNull(message = "deviceId is required")
   val deviceId: Long,
+
+  @field:NotBlank(message = "identifier is required")
+  val identifier: String,
 
   @field:NotBlank(message = "name is required")
   val name: String,
 
   @field:NotBlank(message = "nomisId is required")
   val nomisId: String,
+
+  @field:NotBlank(message = "pncRef is required")
+  val pncRef: String,
 
   @field:Valid
   val positions: List<CrimeMatchingResultPositionRequest>,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/dto/CrimeMatchingResultPositionRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/dto/CrimeMatchingResultPositionRequest.kt
@@ -5,18 +5,24 @@ import jakarta.validation.constraints.NotNull
 import java.time.LocalDateTime
 
 data class CrimeMatchingResultPositionRequest(
+  @field:NotNull(message = "capturedDateTime is required")
+  val capturedDateTime: LocalDateTime,
+
+  @field:NotNull(message = "direction is required")
+  val direction: Long,
+
   @field:NotNull(message = "latitude is required")
   val latitude: Double,
 
   @field:NotNull(message = "longitude is required")
   val longitude: Double,
 
-  @field:NotNull(message = "capturedDateTime is required")
-  val capturedDateTime: LocalDateTime,
+  @field:NotNull(message = "precision is required")
+  val precision: Long,
 
   @field:NotBlank(message = "sequenceLabel is required")
   val sequenceLabel: String,
 
-  @field:NotNull(message = "confidenceCircle is required")
-  val confidenceCircle: Int,
+  @field:NotNull(message = "speed is required")
+  val speed: Long,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/dto/DeviceWearerPositionResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/dto/DeviceWearerPositionResponse.kt
@@ -4,6 +4,6 @@ data class DeviceWearerPositionResponse(
   val latitude: Double,
   val longitude: Double,
   val sequenceLabel: String,
-  val confidence: Int,
+  val precision: Int,
   val capturedDateTime: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/mappers/CrimeVersionMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/mappers/CrimeVersionMapper.kt
@@ -33,7 +33,7 @@ class CrimeVersionMapper(
           latitude = row.wearerLatitude!!,
           longitude = row.wearerLongitude!!,
           sequenceLabel = row.sequenceLabel!!,
-          confidence = row.confidence!!,
+          precision = row.precision!!,
           capturedDateTime = row.capturedDateTime.toString(),
         )
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/model/entity/CrimeMatchingResultDeviceWearer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/model/entity/CrimeMatchingResultDeviceWearer.kt
@@ -10,6 +10,7 @@ import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 import jakarta.persistence.UniqueConstraint
+import java.time.LocalDateTime
 import java.util.UUID
 
 @Entity
@@ -24,6 +25,12 @@ data class CrimeMatchingResultDeviceWearer(
   @Column(name = "id", nullable = false, unique = true)
   val id: UUID = UUID.randomUUID(),
 
+  @Column(nullable = false)
+  val address: String,
+
+  @Column(nullable = false)
+  val dateOfBirth: LocalDateTime,
+
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "crime_matching_result_id", nullable = false)
   val crimeMatchingResult: CrimeMatchingResult,
@@ -31,10 +38,16 @@ data class CrimeMatchingResultDeviceWearer(
   val deviceId: Long,
 
   @Column(nullable = false)
+  val identifier: String,
+
+  @Column(nullable = false)
   val name: String,
 
   @Column(nullable = false)
   val nomisId: String,
+
+  @Column(nullable = false)
+  val pncRef: String,
 
   @OneToMany(mappedBy = "crimeMatchingResultDeviceWearer", cascade = [CascadeType.ALL], fetch = FetchType.LAZY, orphanRemoval = true)
   val positions: MutableList<CrimeMatchingResultPosition> = mutableListOf(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/model/entity/CrimeMatchingResultPosition.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/model/entity/CrimeMatchingResultPosition.kt
@@ -17,19 +17,23 @@ data class CrimeMatchingResultPosition(
   @Column(name = "id", nullable = false, unique = true)
   val id: UUID = UUID.randomUUID(),
 
+  @Column(nullable = false)
+  val capturedDateTime: LocalDateTime,
+
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "crime_matching_result_device_wearer_id", nullable = false)
   val crimeMatchingResultDeviceWearer: CrimeMatchingResultDeviceWearer,
+
+  val direction: Long,
 
   val latitude: Double,
 
   val longitude: Double,
 
-  @Column(nullable = false)
-  val capturedDateTime: LocalDateTime,
+  val precision: Long,
 
   @Column(nullable = false)
   val sequenceLabel: String,
 
-  val confidenceCircle: Int,
+  val speed: Long,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/crimeBatch/CrimeVersionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/crimeBatch/CrimeVersionRepository.kt
@@ -338,7 +338,7 @@ interface CrimeVersionRepository : JpaRepository<CrimeVersion, UUID> {
         cmrp.latitude AS wearerLatitude,
         cmrp.longitude AS wearerLongitude,
         cmrp.sequence_label AS sequenceLabel,
-        cmrp.confidence_circle AS confidence,
+        cmrp.precision AS precision,
         cmrp.captured_date_time AS capturedDateTime
       FROM crime_version cv
       JOIN crime_batch cb ON cb.id = cv.crime_batch_id

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/projection/CrimeVersionProjection.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/projection/CrimeVersionProjection.kt
@@ -25,6 +25,6 @@ interface CrimeVersionProjection {
   val wearerLatitude: Double?
   val wearerLongitude: Double?
   val sequenceLabel: String?
-  val confidence: Int?
+  val precision: Int?
   val capturedDateTime: LocalDateTime?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/crimeMatching/CrimeMatchingRunService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/crimeMatching/CrimeMatchingRunService.kt
@@ -83,9 +83,13 @@ class CrimeMatchingRunService(
   private fun createDeviceWearer(result: CrimeMatchingResult, wearerDto: CrimeMatchingResultDeviceWearerRequest): CrimeMatchingResultDeviceWearer {
     val wearer = CrimeMatchingResultDeviceWearer(
       crimeMatchingResult = result,
+      address = wearerDto.address,
+      dateOfBirth = wearerDto.dateOfBirth,
       deviceId = wearerDto.deviceId,
+      identifier = wearerDto.identifier,
       name = wearerDto.name,
       nomisId = wearerDto.nomisId,
+      pncRef = wearerDto.pncRef,
     )
 
     for (positionDto in wearerDto.positions) {
@@ -98,10 +102,12 @@ class CrimeMatchingRunService(
 
   private fun createPosition(wearer: CrimeMatchingResultDeviceWearer, positionDto: CrimeMatchingResultPositionRequest): CrimeMatchingResultPosition = CrimeMatchingResultPosition(
     crimeMatchingResultDeviceWearer = wearer,
+    capturedDateTime = positionDto.capturedDateTime,
+    direction = positionDto.direction,
     latitude = positionDto.latitude,
     longitude = positionDto.longitude,
-    capturedDateTime = positionDto.capturedDateTime,
+    precision = positionDto.precision,
     sequenceLabel = positionDto.sequenceLabel,
-    confidenceCircle = positionDto.confidenceCircle,
+    speed = positionDto.speed,
   )
 }

--- a/src/main/resources/db/migration/V3__crime_matching_tables.sql
+++ b/src/main/resources/db/migration/V3__crime_matching_tables.sql
@@ -11,9 +11,13 @@ CREATE TABLE crime_matching_result_device_wearer
 (
     id                       UUID   NOT NULL,
     crime_matching_result_id UUID   NOT NULL,
+    address                  VARCHAR(255) NOT NULL,
+    date_of_birth            TIMESTAMP WITHOUT TIME ZONE NOT NULL,
     device_id                BIGINT NOT NULL,
+    identifier               VARCHAR(255) NOT NULL,
     name                     VARCHAR(255) NOT NULL,
     nomis_id                 VARCHAR(255) NOT NULL,
+    pnc_ref                  VARCHAR(255) NOT NULL,
     CONSTRAINT pk_crime_matching_result_device_wearer PRIMARY KEY (id)
 );
 
@@ -21,11 +25,13 @@ CREATE TABLE crime_matching_result_position
 (
     id                                     UUID             NOT NULL,
     crime_matching_result_device_wearer_id UUID             NOT NULL,
+    captured_date_time                     TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+    direction                              BIGINT NOT NULL,
     latitude                               DOUBLE PRECISION NOT NULL,
     longitude                              DOUBLE PRECISION NOT NULL,
-    captured_date_time                     TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+    precision                              BIGINT NOT NULL,
     sequence_label                         VARCHAR(255) NOT NULL,
-    confidence_circle                      INTEGER          NOT NULL,
+    speed                                  BIGINT NOT NULL,
     CONSTRAINT pk_crime_matching_result_position PRIMARY KEY (id)
 );
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/fixtures/CrimeMatchingResultDeviceWearerContext.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/fixtures/CrimeMatchingResultDeviceWearerContext.kt
@@ -14,11 +14,13 @@ class CrimeMatchingResultDeviceWearerContext(
     crimeMatchingResultDeviceWearer.positions.add(
       CrimeMatchingResultPosition(
         crimeMatchingResultDeviceWearer = crimeMatchingResultDeviceWearer,
+        capturedDateTime = capturedDateTime,
+        direction = 10,
         latitude = 10.0,
         longitude = 10.0,
-        capturedDateTime = capturedDateTime,
+        precision = 10,
         sequenceLabel = sequenceLabel,
-        confidenceCircle = 10,
+        speed = 10,
       ),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/fixtures/CrimeMatchingRunContext.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/fixtures/CrimeMatchingRunContext.kt
@@ -2,21 +2,30 @@ package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.integr
 
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.entity.CrimeMatchingResult
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.entity.CrimeMatchingResultDeviceWearer
+import java.time.LocalDateTime
 
 class CrimeMatchingRunContext(
   private val result: CrimeMatchingResult,
 ) {
   fun withMatchedDeviceWearer(
     deviceId: Long,
+    address: String = "address",
+    dateOfBirth: LocalDateTime = LocalDateTime.of(2025, 1, 1, 1, 1),
+    identifier: String = "1",
     name: String = "name",
     nomisId: String = "nomisId",
+    pncRef: String = "pncRef",
     block: CrimeMatchingResultDeviceWearerContext.() -> Unit = {},
   ) {
     val deviceWearer = CrimeMatchingResultDeviceWearer(
       crimeMatchingResult = result,
+      address = address,
+      dateOfBirth = dateOfBirth,
       deviceId = deviceId,
+      identifier = identifier,
       name = name,
       nomisId = nomisId,
+      pncRef = pncRef,
     )
 
     CrimeMatchingResultDeviceWearerContext(deviceWearer).block()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/crimeMatching/CrimeMatchingRunServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/crimeMatching/CrimeMatchingRunServiceTest.kt
@@ -169,23 +169,31 @@ class CrimeMatchingRunServiceTest {
             crimeVersionId = versionId,
             deviceWearers = listOf(
               CrimeMatchingResultDeviceWearerRequest(
+                address = "address",
+                dateOfBirth = LocalDateTime.of(1980, 1, 1, 1, 1, 1),
                 deviceId = 604008982,
+                identifier = "identifier",
                 name = "Richard Gibbons",
                 nomisId = "A5128CZ",
+                pncRef = "ABC",
                 positions = listOf(
                   CrimeMatchingResultPositionRequest(
+                    capturedDateTime = LocalDateTime.of(2026, 1, 16, 8, 12, 0),
+                    direction = 10,
                     latitude = 51.574865,
                     longitude = 0.060977,
-                    capturedDateTime = LocalDateTime.of(2026, 1, 16, 8, 12, 0),
+                    precision = 30,
                     sequenceLabel = "A1",
-                    confidenceCircle = 30,
+                    speed = 10,
                   ),
                   CrimeMatchingResultPositionRequest(
+                    capturedDateTime = LocalDateTime.of(2026, 1, 16, 8, 12, 0),
+                    direction = 10,
                     latitude = 51.574153,
                     longitude = 0.058536,
-                    capturedDateTime = LocalDateTime.of(2026, 1, 16, 8, 12, 0),
+                    precision = 30,
                     sequenceLabel = "A2",
-                    confidenceCircle = 52,
+                    speed = 10,
                   ),
                 ),
               ),
@@ -207,16 +215,23 @@ class CrimeMatchingRunServiceTest {
       assertThat(savedResult.deviceWearers).hasSize(1)
 
       val savedWearer = savedResult.deviceWearers.first()
+      assertThat(savedWearer.address).isEqualTo("address")
+      assertThat(savedWearer.dateOfBirth).isEqualTo(LocalDateTime.of(1980, 1, 1, 1, 1, 1))
       assertThat(savedWearer.deviceId).isEqualTo(604008982)
+      assertThat(savedWearer.identifier).isEqualTo("identifier")
       assertThat(savedWearer.name).isEqualTo("Richard Gibbons")
       assertThat(savedWearer.nomisId).isEqualTo("A5128CZ")
+      assertThat(savedWearer.pncRef).isEqualTo("ABC")
       assertThat(savedWearer.positions).hasSize(2)
 
       val firstPos = savedWearer.positions.first()
-      assertThat(firstPos.sequenceLabel).isEqualTo("A1")
+      assertThat(firstPos.capturedDateTime).isEqualTo(LocalDateTime.of(2026, 1, 16, 8, 12, 0))
+      assertThat(firstPos.direction).isEqualTo(10)
       assertThat(firstPos.latitude).isEqualTo(51.574865)
       assertThat(firstPos.longitude).isEqualTo(0.060977)
-      assertThat(firstPos.confidenceCircle).isEqualTo(30)
+      assertThat(firstPos.precision).isEqualTo(30)
+      assertThat(firstPos.sequenceLabel).isEqualTo("A1")
+      assertThat(firstPos.speed).isEqualTo(10)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/proximityAlert/CrimeVersionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/proximityAlert/CrimeVersionServiceTest.kt
@@ -50,7 +50,7 @@ class CrimeVersionServiceTest {
         on { crimeLatitude } doReturn 10.0
         on { crimeLongitude } doReturn 10.0
         on { sequenceLabel } doReturn "A1"
-        on { confidence } doReturn 10
+        on { precision } doReturn 10
         on { capturedDateTime } doReturn LocalDateTime.now()
       }
 

--- a/src/test/resources/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/resource/create-crime-matching-run-request.json
+++ b/src/test/resources/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/resource/create-crime-matching-run-request.json
@@ -10,23 +10,31 @@
       "crimeVersionId": "252a9a57-337f-4208-908b-2874b75fa10f",
       "deviceWearers": [
         {
+          "address": "address",
+          "dateOfBirth": "1980-01-01T00:00:00",
           "deviceId": 604008982,
           "name": "Richard Gibbons",
+          "identifier": "identifier",
           "nomisId": "A5128CZ",
+          "pncRef": "pncRef",
           "positions": [
             {
+              "capturedDateTime": "2026-01-16T08:12:03",
+              "direction": 10,
               "latitude": 51.574865,
               "longitude": 0.060977,
-              "capturedDateTime": "2026-01-16T08:12:03",
+              "precision": 30,
               "sequenceLabel": "A1",
-              "confidenceCircle": 30
+              "speed": 10
             },
             {
+              "capturedDateTime": "2026-01-16T08:13:03",
+              "direction": 10,
               "latitude": 51.574153,
               "longitude": 0.058536,
-              "capturedDateTime": "2026-01-16T08:13:03",
+              "precision": 52,
               "sequenceLabel": "A2",
-              "confidenceCircle": 52
+              "speed": 10
             }
           ]
         }

--- a/src/test/resources/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/resource/get-crime-version-matching-result-response.json
+++ b/src/test/resources/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/resource/get-crime-version-matching-result-response.json
@@ -22,14 +22,14 @@
               "latitude": 10.0,
               "longitude": 10.0,
               "sequenceLabel": "A1",
-              "confidence": 10,
+              "precision": 10,
               "capturedDateTime": "2025-01-01T00:00"
             },
             {
               "latitude": 10.0,
               "longitude": 10.0,
               "sequenceLabel": "A2",
-              "confidence": 10,
+              "precision": 10,
               "capturedDateTime": "2025-01-01T02:00"
             }
           ]
@@ -43,14 +43,14 @@
               "latitude": 10.0,
               "longitude": 10.0,
               "sequenceLabel": "A1",
-              "confidence": 10,
+              "precision": 10,
               "capturedDateTime": "2025-01-01T00:00"
             },
             {
               "latitude": 10.0,
               "longitude": 10.0,
               "sequenceLabel": "A2",
-              "confidence": 10,
+              "precision": 10,
               "capturedDateTime": "2025-01-01T02:00"
             }
           ]


### PR DESCRIPTION
This is a breaking change because of the update to an old migration. I will update purge the dev database before merging this pull request.

- Added address, dateOfBirth, identifier, pncRef, speed and direction to the `POST /crime-matching-run` endpoint.
- Renamed confidence/confidence circle to precision
- precision / speed / direction are `bigint` in Athena so `Long` in the API.
