### PR TITLE
Expose additional values for proximity alert

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/dto/CrimeVersionResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/dto/CrimeVersionResponse.kt
@@ -4,6 +4,7 @@ data class CrimeVersionResponse(
   val crimeVersionId: String,
   val latestCrimeVersionId: String?,
   val crimeReference: String,
+  val policeForceArea: String,
   val batchId: String,
   val crimeTypeDescription: String,
   val crimeTypeId: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/dto/DeviceWearerResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/dto/DeviceWearerResponse.kt
@@ -1,8 +1,11 @@
 package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.dto
 
 data class DeviceWearerResponse(
+  val address: String,
+  val dateOfBirth: String,
   val name: String,
   val deviceId: Long,
   val nomisId: String,
+  val pncRef: String,
   val positions: MutableList<DeviceWearerPositionResponse> = mutableListOf(),
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/mappers/CrimeVersionMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/mappers/CrimeVersionMapper.kt
@@ -48,9 +48,12 @@ class CrimeVersionMapper(
     val positions = deviceWearer.positions.map(this::deviceWearerPositionToDto).sortedBy { it.capturedDateTime }
 
     val deviceWearer = DeviceWearerResponse(
+      address = deviceWearer.address,
+      dateOfBirth = deviceWearer.dateOfBirth.toString(),
       deviceId = deviceWearer.deviceId,
       name = deviceWearer.name,
       nomisId = deviceWearer.nomisId,
+      pncRef = deviceWearer.pncRef,
     )
     deviceWearer.positions.addAll(positions)
     return deviceWearer

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/mappers/CrimeVersionMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/mappers/CrimeVersionMapper.kt
@@ -25,6 +25,7 @@ class CrimeVersionMapper(
       crimeVersionId = crimeVersion.id.toString(),
       latestCrimeVersionId = latestCrimeVersionId,
       crimeReference = crimeVersion.crime.crimeReference,
+      policeForceArea = crimeVersion.crime.policeForceArea.label,
       batchId = crimeVersion.crimeBatch.batchId,
       crimeTypeDescription = crimeVersion.crimeTypeId.value,
       crimeTypeId = crimeVersion.crimeTypeId.name,

--- a/src/test/resources/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/resource/get-crime-version-duplicate-response.json
+++ b/src/test/resources/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/resource/get-crime-version-duplicate-response.json
@@ -3,6 +3,7 @@
     "crimeVersionId" : "22222222-2222-2222-2222-222222222222",
     "latestCrimeVersionId": null,
     "crimeReference" : "crime1",
+    "policeForceArea": "Metropolitan",
     "batchId" : "Batch2",
     "crimeTypeDescription" : "Aggravated Burglary",
     "crimeTypeId" : "AB",

--- a/src/test/resources/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/resource/get-crime-version-easting-northing-response.json
+++ b/src/test/resources/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/resource/get-crime-version-easting-northing-response.json
@@ -3,6 +3,7 @@
     "crimeVersionId" : "11111111-1111-1111-1111-111111111111",
     "latestCrimeVersionId": null,
     "crimeReference" : "crime1",
+    "policeForceArea": "Metropolitan",
     "batchId" : "Batch1",
     "crimeTypeDescription" : "Aggravated Burglary",
     "crimeTypeId" : "AB",

--- a/src/test/resources/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/resource/get-crime-version-matching-result-response.json
+++ b/src/test/resources/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/resource/get-crime-version-matching-result-response.json
@@ -3,6 +3,7 @@
     "crimeVersionId" : "11111111-1111-1111-1111-111111111111",
     "latestCrimeVersionId": null,
     "crimeReference" : "crime1",
+    "policeForceArea": "Metropolitan",
     "batchId" : "Batch1",
     "crimeTypeDescription" : "Aggravated Burglary",
     "crimeTypeId" : "AB",

--- a/src/test/resources/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/resource/get-crime-version-matching-result-response.json
+++ b/src/test/resources/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/resource/get-crime-version-matching-result-response.json
@@ -15,9 +15,12 @@
     "matching": {
       "deviceWearers": [
         {
+          "address": "address",
+          "dateOfBirth": "2025-01-01T01:01",
           "deviceId": 1,
           "name": "name",
           "nomisId": "nomisId",
+          "pncRef": "pncRef",
           "positions": [
             {
               "capturedDateTime": "2025-01-01T00:00",
@@ -40,9 +43,12 @@
           ]
         },
         {
+          "address": "address",
+          "dateOfBirth": "2025-01-01T01:01",
           "name": "name",
           "deviceId": 2,
           "nomisId": "nomisId",
+          "pncRef": "pncRef",
           "positions": [
             {
               "capturedDateTime": "2025-01-01T00:00",

--- a/src/test/resources/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/resource/get-crime-version-no-matching-result-response.json
+++ b/src/test/resources/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/resource/get-crime-version-no-matching-result-response.json
@@ -3,6 +3,7 @@
     "crimeVersionId" : "11111111-1111-1111-1111-111111111111",
     "latestCrimeVersionId": null,
     "crimeReference" : "crime1",
+    "policeForceArea": "Metropolitan",
     "batchId" : "Batch1",
     "crimeTypeDescription" : "Aggravated Burglary",
     "crimeTypeId" : "AB",

--- a/src/test/resources/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/resource/get-crime-version-older-version-response.json
+++ b/src/test/resources/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/resource/get-crime-version-older-version-response.json
@@ -3,6 +3,7 @@
     "crimeVersionId" : "22222222-2222-2222-2222-222222222222",
     "latestCrimeVersionId": "33333333-3333-3333-3333-333333333333",
     "crimeReference" : "crime1",
+    "policeForceArea": "Metropolitan",
     "batchId" : "Batch2",
     "crimeTypeDescription" : "Aggravated Burglary",
     "crimeTypeId" : "AB",

--- a/src/test/resources/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/resource/get-crime-version-with-updates-response.json
+++ b/src/test/resources/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/resource/get-crime-version-with-updates-response.json
@@ -3,6 +3,7 @@
     "crimeVersionId" : "22222222-2222-2222-2222-222222222222",
     "latestCrimeVersionId": null,
     "crimeReference" : "crime1",
+    "policeForceArea": "Metropolitan",
     "batchId" : "Batch2",
     "crimeTypeDescription" : "Aggravated Burglary",
     "crimeTypeId" : "AB",

--- a/src/test/resources/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/resource/get-crime-version-zero-return-matching-result-response.json
+++ b/src/test/resources/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/resource/get-crime-version-zero-return-matching-result-response.json
@@ -3,6 +3,7 @@
     "crimeVersionId" : "11111111-1111-1111-1111-111111111111",
     "latestCrimeVersionId": null,
     "crimeReference" : "crime1",
+    "policeForceArea": "Metropolitan",
     "batchId" : "Batch1",
     "crimeTypeDescription" : "Aggravated Burglary",
     "crimeTypeId" : "AB",


### PR DESCRIPTION
The proximity alert displays the PFA of the crime and additional values for each device wearer. This updates the `GET /crime-version/{id}` endpoint which is used in creating proximity alerts.