### PR TITLE
Update device activation endpoint with datamart tables

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/client/EmDatastoreClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/client/EmDatastoreClient.kt
@@ -64,7 +64,7 @@ class EmDatastoreClient(
         .outputLocation(properties.outputBucketArn)
         .build()
 
-      var startQueryExecutionRequest = StartQueryExecutionRequest.builder()
+      val startQueryExecutionRequest = StartQueryExecutionRequest.builder()
         .queryString(query.queryString)
         .queryExecutionContext(queryExecutionContext)
         .workGroup(properties.workgroup)
@@ -75,6 +75,7 @@ class EmDatastoreClient(
 
       startQueryExecutionRequest.resultConfiguration(resultConfiguration)
 
+      log.debug("Workgroup: {}", properties.workgroup)
       log.debug("Starting query: {}", query)
 
       val startQueryExecutionResponse = athenaClient.startQueryExecution(startQueryExecutionRequest.build())

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/model/athena/DeviceActivation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/model/athena/DeviceActivation.kt
@@ -2,7 +2,7 @@ package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.
 
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.Table
 
-object DeviceActivation : Table(name = "device_activation") {
+object DeviceActivation : Table(name = "device_activations") {
   val deviceActivationId = long("device_activation_id")
   val deviceId = long("device_id")
   val personId = long("person_id")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/model/athena/DeviceActivation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/model/athena/DeviceActivation.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.athena
+
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.Table
+
+object DeviceActivation : Table(name = "device_activation") {
+  val deviceActivationId = long("device_activation_id")
+  val deviceId = long("device_id")
+  val personId = long("person_id")
+  val deviceActivationDate = date("device_activation_date")
+  val deviceDeactivationDate = date("device_deactivation_date")
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/deviceActivation/DeviceActivationRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/deviceActivation/DeviceActivationRepository.kt
@@ -17,7 +17,7 @@ class DeviceActivationRepository(
   fun findById(id: Long): Optional<DeviceActivation> = Optional.ofNullable(
     this.executeQuery(
       GetDeviceActivationByIdQueryBuilder(
-        athenaClient.properties,
+
         id,
       ).build(),
     ).firstOrNull(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/deviceActivation/GetDeviceActivationByIdQueryBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/deviceActivation/GetDeviceActivationByIdQueryBuilder.kt
@@ -1,22 +1,19 @@
 package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.repository.deviceActivation
 
-import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.config.datastore.DatastoreProperties
-import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.SqlQueryBuilder
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.athena.AthenaQuery
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.athena.DeviceActivation
 
-class GetDeviceActivationByIdQueryBuilder : SqlQueryBuilder {
-  constructor(
-    datastoreProperties: DatastoreProperties,
-    id: Long,
-  ) : super("${datastoreProperties.mdssDatabase}.device_activation") {
-    this.addFields(
-      listOf(
-        "device_activation_id",
-        "device_id",
-        "person_id",
-        "device_activation_date",
-        "device_deactivation_date",
-      ),
+class GetDeviceActivationByIdQueryBuilder(private val id: Long) {
+  fun build(): AthenaQuery = DeviceActivation
+    .select(
+      DeviceActivation.deviceActivationId,
+      DeviceActivation.deviceId,
+      DeviceActivation.personId,
+      DeviceActivation.deviceActivationDate,
+      DeviceActivation.deviceDeactivationDate,
     )
-      .addFilter("device_activation_id", id)
-  }
+    .where {
+      DeviceActivation.deviceActivationId eq id
+    }
+    .prepare()
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/deviceActivation/GetDeviceActivationByIdQueryBuilderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/deviceActivation/GetDeviceActivationByIdQueryBuilderTest.kt
@@ -14,16 +14,16 @@ class GetDeviceActivationByIdQueryBuilderTest {
     assertThat(query.queryString).isEqualTo(
       """
       SELECT 
-        device_activation.device_activation_id, 
-        device_activation.device_id, 
-        device_activation.person_id, 
-        device_activation.device_activation_date, 
-        device_activation.device_deactivation_date 
+        device_activations.device_activation_id, 
+        device_activations.device_id, 
+        device_activations.person_id, 
+        device_activations.device_activation_date, 
+        device_activations.device_deactivation_date 
       FROM 
-        device_activation 
+        device_activations
       WHERE 
-        device_activation.device_activation_id = ?
-      """.trimIndent().replace("\n", "").replace("   ", " "),
+        device_activations.device_activation_id = ?
+      """.trimIndent().replace("\\s+".toRegex(), " "),
     )
     assertThat(query.parameters).isEqualTo(listOf("0"))
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/deviceActivation/GetDeviceActivationByIdQueryBuilderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/deviceActivation/GetDeviceActivationByIdQueryBuilderTest.kt
@@ -1,0 +1,27 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.repository.deviceActivation
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.config.datastore.DatastoreProperties
+
+class GetDeviceActivationByIdQueryBuilderTest {
+  private val dataStoreProperties = DatastoreProperties(
+    fmsDatabase = "",
+    mdssDatabase = "allied_mdss_test",
+    outputBucketArn = "",
+    retryIntervalMs = 0,
+    workgroup = "",
+  )
+
+  @Test
+  fun `it should build a valid query`() {
+    val id: Long = 0
+    val query = GetDeviceActivationByIdQueryBuilder(
+      dataStoreProperties,
+      id,
+    ).build()
+
+    assertThat(query.queryString).isEqualTo("SELECT device_activation_id, device_id, person_id, device_activation_date, device_deactivation_date FROM allied_mdss_test.device_activation t WHERE device_activation_id = ?")
+    assertThat(query.parameters).isEqualTo(listOf(id.toString()))
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/deviceActivation/GetDeviceActivationByIdQueryBuilderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/deviceActivation/GetDeviceActivationByIdQueryBuilderTest.kt
@@ -25,6 +25,6 @@ class GetDeviceActivationByIdQueryBuilderTest {
         device_activation.device_activation_id = ?
       """.trimIndent().replace("\n", "").replace("   ", " "),
     )
-    assertThat(query.parameters).isEqualTo(listOf(id.toString()))
+    assertThat(query.parameters).isEqualTo(listOf("0"))
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/deviceActivation/GetDeviceActivationByIdQueryBuilderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/deviceActivation/GetDeviceActivationByIdQueryBuilderTest.kt
@@ -2,26 +2,29 @@ package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.reposi
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.config.datastore.DatastoreProperties
 
 class GetDeviceActivationByIdQueryBuilderTest {
-  private val dataStoreProperties = DatastoreProperties(
-    fmsDatabase = "",
-    mdssDatabase = "allied_mdss_test",
-    outputBucketArn = "",
-    retryIntervalMs = 0,
-    workgroup = "",
-  )
-
   @Test
   fun `it should build a valid query`() {
     val id: Long = 0
     val query = GetDeviceActivationByIdQueryBuilder(
-      dataStoreProperties,
       id,
     ).build()
 
-    assertThat(query.queryString).isEqualTo("SELECT device_activation_id, device_id, person_id, device_activation_date, device_deactivation_date FROM allied_mdss_test.device_activation t WHERE device_activation_id = ?")
+    assertThat(query.queryString).isEqualTo(
+      """
+      SELECT 
+        device_activation.device_activation_id, 
+        device_activation.device_id, 
+        device_activation.person_id, 
+        device_activation.device_activation_date, 
+        device_activation.device_deactivation_date 
+      FROM 
+        device_activation 
+      WHERE 
+        device_activation.device_activation_id = ?
+      """.trimIndent().replace("\n", "").replace("   ", " "),
+    )
     assertThat(query.parameters).isEqualTo(listOf(id.toString()))
   }
 }


### PR DESCRIPTION
Refactors the query used to retrieve a single device activation from datastore using the datamart tables. Also logs workgroup to help with debugging Athena queries.

Add tests to validate query generation - this was initially implemented using the original query builder (see PR commit log) to validate the query was roughly similar. The main changes are the removed of the database name and the addition of fully qualified column names.

N.B. This will break the `GET /device-actions/{id}` route with this error because additional work is needed to set the default database used for queries. The database is no longer referenced for each table in each query because datastore are presenting a single "EMAC" database with all the info we need.
```
User: <redacted> is not authorized to perform: glue:GetDatabase on resource:arn:aws:glue:eu-west-2:<redacted>:database/default because no identity-based policy allows the glue:GetDatabase action
```