### PR TITLE
Update get positions endpoint with datamart tables

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/dto/PositionResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/dto/PositionResponse.kt
@@ -20,7 +20,7 @@ data class PositionResponse(
     precision = position.positionPrecision,
     speed = position.positionSpeed,
     direction = position.positionDirection,
-    timestamp = position.positionGpsDate.toString(),
+    timestamp = position.positionRecordedDate.toString(),
     geolocationMechanism = GeolocationMechanism.from(position.positionLbs).toString(),
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/helpers/querybuilders/Table.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/helpers/querybuilders/Table.kt
@@ -11,6 +11,8 @@ open class Table(val name: String) : ColumnSet() {
 
   fun long(name: String): Column<Long> = registerColumn(name)
 
+  fun double(name: String): Column<Double> = registerColumn(name)
+
   fun varchar(name: String): Column<String> = registerColumn(name)
 
   fun date(name: String): Column<ZonedDateTime> = registerColumn(name)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/helpers/querybuilders/conditions/CompositeCondition.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/helpers/querybuilders/conditions/CompositeCondition.kt
@@ -15,8 +15,8 @@ open class CompositeCondition(private val op: String) : Condition() {
     0 -> ""
     1 -> conditions.first().toString()
     else -> conditions.joinToString(
-      prefix = "(",
-      postfix = ")",
+      prefix = "( ",
+      postfix = " )",
       separator = " $op ",
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/model/athena/Position.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/model/athena/Position.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.athena
+
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.Table
+
+object Position : Table("position") {
+  val deviceId = long("device_id")
+  val personId = long("person_id")
+  val positionId = long("position_id")
+  val positionLatitude = double("position_latitude")
+  val positionLongitude = double("position_longitude")
+  val positionPrecision = long("position_precision")
+  val positionSpeed = long("position_speed")
+  val positionDirection = long("position_direction")
+  val positionRecordedDate = date("position_recorded_date")
+  val positionLbs = long("position_lbs")
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/model/entity/Position.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/model/entity/Position.kt
@@ -17,7 +17,7 @@ data class Position(
   val positionDirection: Long,
 
   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss[.[SSSSSS][SSS]]")
-  val positionGpsDate: LocalDateTime,
+  val positionRecordedDate: LocalDateTime,
 
   val positionLbs: Long,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/position/GetPositionsByDeviceActivationId.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/position/GetPositionsByDeviceActivationId.kt
@@ -1,48 +1,48 @@
 package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.repository.position
 
-import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.config.datastore.DatastoreProperties
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.JoinType
-import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.SqlQueryBuilder
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.functions.AthenaFunctions
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.athena.AthenaQuery
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.athena.DeviceActivation
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.athena.Position
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.entity.GeolocationMechanism
 import java.time.ZonedDateTime
 
-class GetPositionsByDeviceActivationId : SqlQueryBuilder {
-  constructor(
-    datastoreProperties: DatastoreProperties,
-    id: Long,
-    geolocationMechanism: GeolocationMechanism?,
-    from: ZonedDateTime?,
-    to: ZonedDateTime?,
-  ) : super("${datastoreProperties.mdssDatabase}.device_activation", "d") {
-    this.addFields(
-      listOf(
-        "p.position_id",
-        "p.position_latitude",
-        "p.position_longitude",
-        "p.position_precision",
-        "p.position_speed",
-        "p.position_direction",
-        "p.position_gps_date",
-        "p.position_lbs",
-      ),
+class GetPositionsByDeviceActivationId(
+  private val id: Long,
+  private val geolocationMechanism: GeolocationMechanism?,
+  private val from: ZonedDateTime?,
+  private val to: ZonedDateTime?,
+) {
+  fun build(): AthenaQuery = DeviceActivation
+    .join(Position, JoinType.INNER) {
+      DeviceActivation.deviceId eq Position.deviceId
+      DeviceActivation.personId eq Position.personId
+    }
+    .select(
+      Position.positionId,
+      Position.positionLatitude,
+      Position.positionLongitude,
+      Position.positionPrecision,
+      Position.positionSpeed,
+      Position.positionDirection,
+      Position.positionRecordedDate,
+      Position.positionLbs,
     )
-      .addJoin(
-        "${datastoreProperties.mdssDatabase}.position p",
-        "d.device_id = p.device_id AND d.person_id = p.person_id",
-        JoinType.INNER,
-      )
-      .addFilter("d.device_activation_id", id)
+    .where {
+      DeviceActivation.deviceActivationId eq id
 
-    if (geolocationMechanism != null) {
-      this.addFilter("p.position_lbs", geolocationMechanism.value)
-    }
+      geolocationMechanism?.let {
+        Position.positionLbs eq geolocationMechanism.value
+      }
 
-    if (from != null) {
-      this.greaterEq("p.position_gps_date", from)
-    }
+      from?.let {
+        Position.positionRecordedDate gte AthenaFunctions.fromIso8601Timestamp(from)
+      }
 
-    if (to != null) {
-      this.lessEq("p.position_gps_date", to)
+      to?.let {
+        Position.positionRecordedDate lte AthenaFunctions.fromIso8601Timestamp(to)
+      }
     }
-  }
+    .prepare()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/position/PositionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/position/PositionRepository.kt
@@ -22,7 +22,6 @@ class PositionRepository(
     to: ZonedDateTime?,
   ): List<Position> = this.executeQuery(
     GetPositionsByDeviceActivationId(
-      athenaClient.properties,
       id,
       geolocationMechanism,
       from,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/fixtures/queries/AthenaQueries.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/fixtures/queries/AthenaQueries.kt
@@ -1,0 +1,103 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.fixtures.queries
+
+object AthenaQueries {
+  val SelectPositionsByDeviceActivationId = """
+    SELECT 
+      position.position_id,
+      position.position_latitude,
+      position.position_longitude,
+      position.position_precision,
+      position.position_speed,
+      position.position_direction,
+      position.position_recorded_date,
+      position.position_lbs
+    FROM 
+      device_activations
+    INNER JOIN
+      position ON ( device_activations.device_id = position.device_id AND device_activations.person_id = position.person_id )
+    WHERE 
+      device_activations.device_activation_id = ?
+  """.trimIndent().replace("\\s+".toRegex(), " ")
+
+  val SelectPositionsByDeviceActivationIdAndGeolocationMechanism = """
+    SELECT 
+      position.position_id,
+      position.position_latitude,
+      position.position_longitude,
+      position.position_precision,
+      position.position_speed,
+      position.position_direction,
+      position.position_recorded_date,
+      position.position_lbs
+    FROM 
+      device_activations
+    INNER JOIN
+      position ON ( device_activations.device_id = position.device_id AND device_activations.person_id = position.person_id )
+    WHERE (
+      device_activations.device_activation_id = ?
+      AND position.position_lbs = ? 
+    )
+  """.trimIndent().replace("\\s+".toRegex(), " ")
+
+  val SelectPositionsByDeviceActivationIdAndFromDate = """
+    SELECT 
+      position.position_id,
+      position.position_latitude,
+      position.position_longitude,
+      position.position_precision,
+      position.position_speed,
+      position.position_direction,
+      position.position_recorded_date,
+      position.position_lbs
+    FROM 
+      device_activations
+    INNER JOIN
+      position ON ( device_activations.device_id = position.device_id AND device_activations.person_id = position.person_id )
+    WHERE (
+      device_activations.device_activation_id = ?
+      AND position.position_recorded_date >= from_iso8601_timestamp(?) 
+    )
+  """.trimIndent().replace("\\s+".toRegex(), " ")
+
+  val SelectPositionsByDeviceActivationIdAndToDate = """
+    SELECT 
+      position.position_id,
+      position.position_latitude,
+      position.position_longitude,
+      position.position_precision,
+      position.position_speed,
+      position.position_direction,
+      position.position_recorded_date,
+      position.position_lbs
+    FROM 
+      device_activations
+    INNER JOIN
+      position ON ( device_activations.device_id = position.device_id AND device_activations.person_id = position.person_id )
+    WHERE (
+      device_activations.device_activation_id = ?
+      AND position.position_recorded_date <= from_iso8601_timestamp(?) 
+    )
+  """.trimIndent().replace("\\s+".toRegex(), " ")
+
+  val SelectPositionsByDeviceActivationIdAndGeolocationMechanismAndFromDateAndToDate = """
+    SELECT 
+      position.position_id,
+      position.position_latitude,
+      position.position_longitude,
+      position.position_precision,
+      position.position_speed,
+      position.position_direction,
+      position.position_recorded_date,
+      position.position_lbs
+    FROM 
+      device_activations
+    INNER JOIN
+      position ON ( device_activations.device_id = position.device_id AND device_activations.person_id = position.person_id )
+    WHERE (
+      device_activations.device_activation_id = ?
+      AND position.position_lbs = ?
+      AND position.position_recorded_date >= from_iso8601_timestamp(?)
+      AND position.position_recorded_date <= from_iso8601_timestamp(?)
+    )
+  """.trimIndent().replace("\\s+".toRegex(), " ")
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/helper/queryBuilders/QueryBuilderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/helper/queryBuilders/QueryBuilderTest.kt
@@ -78,7 +78,7 @@ class QueryBuilderTest {
       }
       .prepare()
 
-    assertThat(query.queryString).isEqualTo("SELECT * FROM test_table WHERE (test_table.test_column_1 = ? AND test_table.test_column_2 = ?)")
+    assertThat(query.queryString).isEqualTo("SELECT * FROM test_table WHERE ( test_table.test_column_1 = ? AND test_table.test_column_2 = ? )")
     assertThat(query.parameters).isEqualTo(listOf("1", "'foo'"))
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/IntegrationTestBase.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.integration
 
-import com.github.tomakehurst.wiremock.client.WireMock.containing
 import com.github.tomakehurst.wiremock.client.WireMock.equalTo
 import com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath
 import com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor
@@ -153,7 +152,7 @@ abstract class IntegrationTestBase {
     val requestPattern = postRequestedFor(urlPathEqualTo("/"))
       .withHeader("X-Amz-Target", equalTo("AmazonAthena.StartQueryExecution"))
       .withRequestBody(
-        matchingJsonPath("QueryString", containing(query)),
+        matchingJsonPath("QueryString", equalTo(query)),
       )
 
     for (executionParameter in executionParameters) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/resource/DeviceActivationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/resource/DeviceActivationControllerTest.kt
@@ -11,6 +11,7 @@ import org.springframework.test.web.reactive.server.expectBody
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.dto.DeviceActivationResponse
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.dto.PositionResponse
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.dto.Response
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.fixtures.queries.AthenaQueries
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.integration.IntegrationTestBase
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
@@ -436,7 +437,7 @@ class DeviceActivationControllerTest : IntegrationTestBase() {
 
       // Check that the WHERE clause include the geolocation mechanism filter
       verifyAthenaStartQueryExecutionWithQuery(
-        "WHERE d.device_activation_id = ? AND p.position_lbs = ?",
+        AthenaQueries.SelectPositionsByDeviceActivationIdAndGeolocationMechanism,
         listOf("1", "1"),
       )
     }
@@ -462,7 +463,7 @@ class DeviceActivationControllerTest : IntegrationTestBase() {
 
       // Check that the WHERE clause include the geolocation mechanism filter
       verifyAthenaStartQueryExecutionWithQuery(
-        "WHERE d.device_activation_id = ? AND p.position_gps_date >= from_iso8601_timestamp(?)",
+        AthenaQueries.SelectPositionsByDeviceActivationIdAndFromDate,
         listOf("1", "'2025-01-01T00:00Z'"),
       )
     }
@@ -488,7 +489,7 @@ class DeviceActivationControllerTest : IntegrationTestBase() {
 
       // Check that the WHERE clause include the geolocation mechanism filter
       verifyAthenaStartQueryExecutionWithQuery(
-        "WHERE d.device_activation_id = ? AND p.position_gps_date <= from_iso8601_timestamp(?)",
+        AthenaQueries.SelectPositionsByDeviceActivationIdAndToDate,
         listOf("1", "'2025-01-01T00:00Z'"),
       )
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/position/GetPositionsByDeviceActivationIdTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/position/GetPositionsByDeviceActivationIdTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.reposi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.test.context.ActiveProfiles
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.fixtures.queries.AthenaQueries
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.entity.GeolocationMechanism
 import java.time.LocalDateTime
 import java.time.ZoneOffset
@@ -21,23 +22,7 @@ class GetPositionsByDeviceActivationIdTest {
     ).build()
 
     assertThat(query.queryString).isEqualTo(
-      """
-      SELECT 
-        position.position_id,
-        position.position_latitude,
-        position.position_longitude,
-        position.position_precision,
-        position.position_speed,
-        position.position_direction,
-        position.position_recorded_date,
-        position.position_lbs
-      FROM 
-        device_activations
-      INNER JOIN
-        position ON ( device_activations.device_id = position.device_id AND device_activations.person_id = position.person_id )
-      WHERE 
-        device_activations.device_activation_id = ?
-      """.trimIndent().replace("\\s+".toRegex(), " "),
+      AthenaQueries.SelectPositionsByDeviceActivationId,
     )
     assertThat(query.parameters).isEqualTo(listOf("1"))
   }
@@ -53,25 +38,7 @@ class GetPositionsByDeviceActivationIdTest {
     ).build()
 
     assertThat(query.queryString).isEqualTo(
-      """
-      SELECT 
-        position.position_id,
-        position.position_latitude,
-        position.position_longitude,
-        position.position_precision,
-        position.position_speed,
-        position.position_direction,
-        position.position_recorded_date,
-        position.position_lbs
-      FROM 
-        device_activations
-      INNER JOIN
-        position ON ( device_activations.device_id = position.device_id AND device_activations.person_id = position.person_id )
-      WHERE (
-        device_activations.device_activation_id = ?
-        AND position.position_lbs = ? 
-      )
-      """.trimIndent().replace("\\s+".toRegex(), " "),
+      AthenaQueries.SelectPositionsByDeviceActivationIdAndGeolocationMechanism,
     )
     assertThat(query.parameters).isEqualTo(listOf("1", "4"))
   }
@@ -87,25 +54,7 @@ class GetPositionsByDeviceActivationIdTest {
     ).build()
 
     assertThat(query.queryString).isEqualTo(
-      """
-      SELECT 
-        position.position_id,
-        position.position_latitude,
-        position.position_longitude,
-        position.position_precision,
-        position.position_speed,
-        position.position_direction,
-        position.position_recorded_date,
-        position.position_lbs
-      FROM 
-        device_activations
-      INNER JOIN
-        position ON ( device_activations.device_id = position.device_id AND device_activations.person_id = position.person_id )
-      WHERE (
-        device_activations.device_activation_id = ?
-        AND position.position_recorded_date >= from_iso8601_timestamp(?) 
-      )
-      """.trimIndent().replace("\\s+".toRegex(), " "),
+      AthenaQueries.SelectPositionsByDeviceActivationIdAndFromDate,
     )
     assertThat(query.parameters).isEqualTo(listOf("1", "'2020-01-01T01:00Z'"))
   }
@@ -121,25 +70,7 @@ class GetPositionsByDeviceActivationIdTest {
     ).build()
 
     assertThat(query.queryString).isEqualTo(
-      """
-      SELECT 
-        position.position_id,
-        position.position_latitude,
-        position.position_longitude,
-        position.position_precision,
-        position.position_speed,
-        position.position_direction,
-        position.position_recorded_date,
-        position.position_lbs
-      FROM 
-        device_activations
-      INNER JOIN
-        position ON ( device_activations.device_id = position.device_id AND device_activations.person_id = position.person_id )
-      WHERE (
-        device_activations.device_activation_id = ?
-        AND position.position_recorded_date <= from_iso8601_timestamp(?) 
-      )
-      """.trimIndent().replace("\\s+".toRegex(), " "),
+      AthenaQueries.SelectPositionsByDeviceActivationIdAndToDate,
     )
     assertThat(query.parameters).isEqualTo(listOf("1", "'2020-01-01T01:00Z'"))
   }
@@ -155,27 +86,7 @@ class GetPositionsByDeviceActivationIdTest {
     ).build()
 
     assertThat(query.queryString).isEqualTo(
-      """
-      SELECT 
-        position.position_id,
-        position.position_latitude,
-        position.position_longitude,
-        position.position_precision,
-        position.position_speed,
-        position.position_direction,
-        position.position_recorded_date,
-        position.position_lbs
-      FROM 
-        device_activations
-      INNER JOIN
-        position ON ( device_activations.device_id = position.device_id AND device_activations.person_id = position.person_id )
-      WHERE (
-        device_activations.device_activation_id = ?
-        AND position.position_lbs = ?
-        AND position.position_recorded_date >= from_iso8601_timestamp(?)
-        AND position.position_recorded_date <= from_iso8601_timestamp(?)
-      )
-      """.trimIndent().replace("\\s+".toRegex(), " "),
+      AthenaQueries.SelectPositionsByDeviceActivationIdAndGeolocationMechanismAndFromDateAndToDate,
     )
     assertThat(query.parameters).isEqualTo(listOf("1", "5", "'2020-01-01T01:00Z'", "'2020-01-02T01:00Z'"))
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/position/GetPositionsByDeviceActivationIdTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/position/GetPositionsByDeviceActivationIdTest.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.reposi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.test.context.ActiveProfiles
-import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.config.datastore.DatastoreProperties
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.entity.GeolocationMechanism
 import java.time.LocalDateTime
 import java.time.ZoneOffset
@@ -11,42 +10,33 @@ import java.time.ZonedDateTime
 
 @ActiveProfiles("test")
 class GetPositionsByDeviceActivationIdTest {
-  private val datastoreProperties = DatastoreProperties(
-    fmsDatabase = "",
-    mdssDatabase = "allied_mdss_dev",
-    outputBucketArn = "",
-    retryIntervalMs = 0,
-    workgroup = ""
-  )
-
   @Test
   fun `it should build a valid query without additional filters`() {
     val id: Long = 1
     val query = GetPositionsByDeviceActivationId(
-      datastoreProperties,
       id,
       null,
       null,
-      null
+      null,
     ).build()
 
     assertThat(query.queryString).isEqualTo(
       """
       SELECT 
-        p.position_id,
-        p.position_latitude,
-        p.position_longitude,
-        p.position_precision,
-        p.position_speed,
-        p.position_direction,
-        p.position_gps_date,
-        p.position_lbs
+        position.position_id,
+        position.position_latitude,
+        position.position_longitude,
+        position.position_precision,
+        position.position_speed,
+        position.position_direction,
+        position.position_recorded_date,
+        position.position_lbs
       FROM 
-        allied_mdss_dev.device_activation d
+        device_activations
       INNER JOIN
-        allied_mdss_dev.position p ON ( d.device_id = p.device_id AND d.person_id = p.person_id )
+        position ON ( device_activations.device_id = position.device_id AND device_activations.person_id = position.person_id )
       WHERE 
-        d.device_activation_id = ?
+        device_activations.device_activation_id = ?
       """.trimIndent().replace("\\s+".toRegex(), " "),
     )
     assertThat(query.parameters).isEqualTo(listOf("1"))
@@ -56,32 +46,31 @@ class GetPositionsByDeviceActivationIdTest {
   fun `it should build a valid query with a geoLocationMechanism filter`() {
     val id: Long = 1
     val query = GetPositionsByDeviceActivationId(
-      datastoreProperties,
       id,
       GeolocationMechanism.RF,
       null,
-      null
+      null,
     ).build()
 
     assertThat(query.queryString).isEqualTo(
       """
       SELECT 
-        p.position_id,
-        p.position_latitude,
-        p.position_longitude,
-        p.position_precision,
-        p.position_speed,
-        p.position_direction,
-        p.position_gps_date,
-        p.position_lbs
+        position.position_id,
+        position.position_latitude,
+        position.position_longitude,
+        position.position_precision,
+        position.position_speed,
+        position.position_direction,
+        position.position_recorded_date,
+        position.position_lbs
       FROM 
-        allied_mdss_dev.device_activation d
+        device_activations
       INNER JOIN
-        allied_mdss_dev.position p ON ( d.device_id = p.device_id AND d.person_id = p.person_id )
-      WHERE 
-        d.device_activation_id = ?
-      AND
-        p.position_lbs = ?
+        position ON ( device_activations.device_id = position.device_id AND device_activations.person_id = position.person_id )
+      WHERE (
+        device_activations.device_activation_id = ?
+        AND position.position_lbs = ? 
+      )
       """.trimIndent().replace("\\s+".toRegex(), " "),
     )
     assertThat(query.parameters).isEqualTo(listOf("1", "4"))
@@ -91,32 +80,31 @@ class GetPositionsByDeviceActivationIdTest {
   fun `it should build a valid query with a from filter`() {
     val id: Long = 1
     val query = GetPositionsByDeviceActivationId(
-      datastoreProperties,
       id,
       null,
       ZonedDateTime.of(LocalDateTime.of(2020, 1, 1, 1, 0, 0), ZoneOffset.UTC),
-      null
+      null,
     ).build()
 
     assertThat(query.queryString).isEqualTo(
       """
       SELECT 
-        p.position_id,
-        p.position_latitude,
-        p.position_longitude,
-        p.position_precision,
-        p.position_speed,
-        p.position_direction,
-        p.position_gps_date,
-        p.position_lbs
+        position.position_id,
+        position.position_latitude,
+        position.position_longitude,
+        position.position_precision,
+        position.position_speed,
+        position.position_direction,
+        position.position_recorded_date,
+        position.position_lbs
       FROM 
-        allied_mdss_dev.device_activation d
+        device_activations
       INNER JOIN
-        allied_mdss_dev.position p ON ( d.device_id = p.device_id AND d.person_id = p.person_id )
-      WHERE 
-        d.device_activation_id = ?
-      AND
-        p.position_gps_date >= from_iso8601_timestamp(?)
+        position ON ( device_activations.device_id = position.device_id AND device_activations.person_id = position.person_id )
+      WHERE (
+        device_activations.device_activation_id = ?
+        AND position.position_recorded_date >= from_iso8601_timestamp(?) 
+      )
       """.trimIndent().replace("\\s+".toRegex(), " "),
     )
     assertThat(query.parameters).isEqualTo(listOf("1", "'2020-01-01T01:00Z'"))
@@ -126,7 +114,6 @@ class GetPositionsByDeviceActivationIdTest {
   fun `it should build a valid query with a to filter`() {
     val id: Long = 1
     val query = GetPositionsByDeviceActivationId(
-      datastoreProperties,
       id,
       null,
       null,
@@ -136,22 +123,22 @@ class GetPositionsByDeviceActivationIdTest {
     assertThat(query.queryString).isEqualTo(
       """
       SELECT 
-        p.position_id,
-        p.position_latitude,
-        p.position_longitude,
-        p.position_precision,
-        p.position_speed,
-        p.position_direction,
-        p.position_gps_date,
-        p.position_lbs
+        position.position_id,
+        position.position_latitude,
+        position.position_longitude,
+        position.position_precision,
+        position.position_speed,
+        position.position_direction,
+        position.position_recorded_date,
+        position.position_lbs
       FROM 
-        allied_mdss_dev.device_activation d
+        device_activations
       INNER JOIN
-        allied_mdss_dev.position p ON ( d.device_id = p.device_id AND d.person_id = p.person_id )
-      WHERE 
-        d.device_activation_id = ?
-      AND
-        p.position_gps_date <= from_iso8601_timestamp(?)
+        position ON ( device_activations.device_id = position.device_id AND device_activations.person_id = position.person_id )
+      WHERE (
+        device_activations.device_activation_id = ?
+        AND position.position_recorded_date <= from_iso8601_timestamp(?) 
+      )
       """.trimIndent().replace("\\s+".toRegex(), " "),
     )
     assertThat(query.parameters).isEqualTo(listOf("1", "'2020-01-01T01:00Z'"))
@@ -161,7 +148,6 @@ class GetPositionsByDeviceActivationIdTest {
   fun `it should build a valid query with all filters`() {
     val id: Long = 1
     val query = GetPositionsByDeviceActivationId(
-      datastoreProperties,
       id,
       GeolocationMechanism.LBS,
       ZonedDateTime.of(LocalDateTime.of(2020, 1, 1, 1, 0, 0), ZoneOffset.UTC),
@@ -171,26 +157,24 @@ class GetPositionsByDeviceActivationIdTest {
     assertThat(query.queryString).isEqualTo(
       """
       SELECT 
-        p.position_id,
-        p.position_latitude,
-        p.position_longitude,
-        p.position_precision,
-        p.position_speed,
-        p.position_direction,
-        p.position_gps_date,
-        p.position_lbs
+        position.position_id,
+        position.position_latitude,
+        position.position_longitude,
+        position.position_precision,
+        position.position_speed,
+        position.position_direction,
+        position.position_recorded_date,
+        position.position_lbs
       FROM 
-        allied_mdss_dev.device_activation d
+        device_activations
       INNER JOIN
-        allied_mdss_dev.position p ON ( d.device_id = p.device_id AND d.person_id = p.person_id )
-      WHERE 
-        d.device_activation_id = ?
-      AND 
-        p.position_lbs = ?
-      AND
-        p.position_gps_date >= from_iso8601_timestamp(?)
-      AND
-        p.position_gps_date <= from_iso8601_timestamp(?)
+        position ON ( device_activations.device_id = position.device_id AND device_activations.person_id = position.person_id )
+      WHERE (
+        device_activations.device_activation_id = ?
+        AND position.position_lbs = ?
+        AND position.position_recorded_date >= from_iso8601_timestamp(?)
+        AND position.position_recorded_date <= from_iso8601_timestamp(?)
+      )
       """.trimIndent().replace("\\s+".toRegex(), " "),
     )
     assertThat(query.parameters).isEqualTo(listOf("1", "5", "'2020-01-01T01:00Z'", "'2020-01-02T01:00Z'"))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/position/GetPositionsByDeviceActivationIdTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/position/GetPositionsByDeviceActivationIdTest.kt
@@ -1,0 +1,198 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.repository.position
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.test.context.ActiveProfiles
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.config.datastore.DatastoreProperties
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.entity.GeolocationMechanism
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+
+@ActiveProfiles("test")
+class GetPositionsByDeviceActivationIdTest {
+  private val datastoreProperties = DatastoreProperties(
+    fmsDatabase = "",
+    mdssDatabase = "allied_mdss_dev",
+    outputBucketArn = "",
+    retryIntervalMs = 0,
+    workgroup = ""
+  )
+
+  @Test
+  fun `it should build a valid query without additional filters`() {
+    val id: Long = 1
+    val query = GetPositionsByDeviceActivationId(
+      datastoreProperties,
+      id,
+      null,
+      null,
+      null
+    ).build()
+
+    assertThat(query.queryString).isEqualTo(
+      """
+      SELECT 
+        p.position_id,
+        p.position_latitude,
+        p.position_longitude,
+        p.position_precision,
+        p.position_speed,
+        p.position_direction,
+        p.position_gps_date,
+        p.position_lbs
+      FROM 
+        allied_mdss_dev.device_activation d
+      INNER JOIN
+        allied_mdss_dev.position p ON ( d.device_id = p.device_id AND d.person_id = p.person_id )
+      WHERE 
+        d.device_activation_id = ?
+      """.trimIndent().replace("\\s+".toRegex(), " "),
+    )
+    assertThat(query.parameters).isEqualTo(listOf("1"))
+  }
+
+  @Test
+  fun `it should build a valid query with a geoLocationMechanism filter`() {
+    val id: Long = 1
+    val query = GetPositionsByDeviceActivationId(
+      datastoreProperties,
+      id,
+      GeolocationMechanism.RF,
+      null,
+      null
+    ).build()
+
+    assertThat(query.queryString).isEqualTo(
+      """
+      SELECT 
+        p.position_id,
+        p.position_latitude,
+        p.position_longitude,
+        p.position_precision,
+        p.position_speed,
+        p.position_direction,
+        p.position_gps_date,
+        p.position_lbs
+      FROM 
+        allied_mdss_dev.device_activation d
+      INNER JOIN
+        allied_mdss_dev.position p ON ( d.device_id = p.device_id AND d.person_id = p.person_id )
+      WHERE 
+        d.device_activation_id = ?
+      AND
+        p.position_lbs = ?
+      """.trimIndent().replace("\\s+".toRegex(), " "),
+    )
+    assertThat(query.parameters).isEqualTo(listOf("1", "4"))
+  }
+
+  @Test
+  fun `it should build a valid query with a from filter`() {
+    val id: Long = 1
+    val query = GetPositionsByDeviceActivationId(
+      datastoreProperties,
+      id,
+      null,
+      ZonedDateTime.of(LocalDateTime.of(2020, 1, 1, 1, 0, 0), ZoneOffset.UTC),
+      null
+    ).build()
+
+    assertThat(query.queryString).isEqualTo(
+      """
+      SELECT 
+        p.position_id,
+        p.position_latitude,
+        p.position_longitude,
+        p.position_precision,
+        p.position_speed,
+        p.position_direction,
+        p.position_gps_date,
+        p.position_lbs
+      FROM 
+        allied_mdss_dev.device_activation d
+      INNER JOIN
+        allied_mdss_dev.position p ON ( d.device_id = p.device_id AND d.person_id = p.person_id )
+      WHERE 
+        d.device_activation_id = ?
+      AND
+        p.position_gps_date >= from_iso8601_timestamp(?)
+      """.trimIndent().replace("\\s+".toRegex(), " "),
+    )
+    assertThat(query.parameters).isEqualTo(listOf("1", "'2020-01-01T01:00Z'"))
+  }
+
+  @Test
+  fun `it should build a valid query with a to filter`() {
+    val id: Long = 1
+    val query = GetPositionsByDeviceActivationId(
+      datastoreProperties,
+      id,
+      null,
+      null,
+      ZonedDateTime.of(LocalDateTime.of(2020, 1, 1, 1, 0, 0), ZoneOffset.UTC),
+    ).build()
+
+    assertThat(query.queryString).isEqualTo(
+      """
+      SELECT 
+        p.position_id,
+        p.position_latitude,
+        p.position_longitude,
+        p.position_precision,
+        p.position_speed,
+        p.position_direction,
+        p.position_gps_date,
+        p.position_lbs
+      FROM 
+        allied_mdss_dev.device_activation d
+      INNER JOIN
+        allied_mdss_dev.position p ON ( d.device_id = p.device_id AND d.person_id = p.person_id )
+      WHERE 
+        d.device_activation_id = ?
+      AND
+        p.position_gps_date <= from_iso8601_timestamp(?)
+      """.trimIndent().replace("\\s+".toRegex(), " "),
+    )
+    assertThat(query.parameters).isEqualTo(listOf("1", "'2020-01-01T01:00Z'"))
+  }
+
+  @Test
+  fun `it should build a valid query with all filters`() {
+    val id: Long = 1
+    val query = GetPositionsByDeviceActivationId(
+      datastoreProperties,
+      id,
+      GeolocationMechanism.LBS,
+      ZonedDateTime.of(LocalDateTime.of(2020, 1, 1, 1, 0, 0), ZoneOffset.UTC),
+      ZonedDateTime.of(LocalDateTime.of(2020, 1, 2, 1, 0, 0), ZoneOffset.UTC),
+    ).build()
+
+    assertThat(query.queryString).isEqualTo(
+      """
+      SELECT 
+        p.position_id,
+        p.position_latitude,
+        p.position_longitude,
+        p.position_precision,
+        p.position_speed,
+        p.position_direction,
+        p.position_gps_date,
+        p.position_lbs
+      FROM 
+        allied_mdss_dev.device_activation d
+      INNER JOIN
+        allied_mdss_dev.position p ON ( d.device_id = p.device_id AND d.person_id = p.person_id )
+      WHERE 
+        d.device_activation_id = ?
+      AND 
+        p.position_lbs = ?
+      AND
+        p.position_gps_date >= from_iso8601_timestamp(?)
+      AND
+        p.position_gps_date <= from_iso8601_timestamp(?)
+      """.trimIndent().replace("\\s+".toRegex(), " "),
+    )
+    assertThat(query.parameters).isEqualTo(listOf("1", "5", "'2020-01-01T01:00Z'", "'2020-01-02T01:00Z'"))
+  }
+}

--- a/src/test/resources/__files/athenaResponses/device-activation.positions.empty.success.json
+++ b/src/test/resources/__files/athenaResponses/device-activation.positions.empty.success.json
@@ -77,8 +77,8 @@
         {
           "CaseSensitive": false,
           "CatalogName": "hive",
-          "Label": "position_gps_date",
-          "Name": "position_gps_date",
+          "Label": "position_recorded_date",
+          "Name": "position_recorded_date",
           "Nullable": "UNKNOWN",
           "Precision": 0,
           "Scale": 0,
@@ -122,7 +122,7 @@
             "VarCharValue": "position_direction"
           },
           {
-            "VarCharValue": "position_gps_date"
+            "VarCharValue": "position_recorded_date"
           },
           {
             "VarCharValue": "position_lbs"

--- a/src/test/resources/__files/athenaResponses/device-activation.positions.some.success.json
+++ b/src/test/resources/__files/athenaResponses/device-activation.positions.some.success.json
@@ -77,8 +77,8 @@
         {
           "CaseSensitive": false,
           "CatalogName": "hive",
-          "Label": "position_gps_date",
-          "Name": "position_gps_date",
+          "Label": "position_recorded_date",
+          "Name": "position_recorded_date",
           "Nullable": "UNKNOWN",
           "Precision": 0,
           "Scale": 0,
@@ -122,7 +122,7 @@
             "VarCharValue": "position_direction"
           },
           {
-            "VarCharValue": "position_gps_date"
+            "VarCharValue": "position_recorded_date"
           },
           {
             "VarCharValue": "position_lbs"


### PR DESCRIPTION
Refactors the query used to retrieve a positions for a given device activation from datastore using the datamart tables. Conditionally adds additional filters (i.e. GeoLocationMechanism and date time window).

Add tests to validate query generation - this was initially implemented using the original query builder (see PR commit log) to validate the query was roughly similar. The main changes are the removed of the database name and the addition of fully qualified column names. Also removed aliases in favour of using full table names (simply because I think it looks a bit cleaner when righting the query).

Previously, we only checked that the correct "where" position was being sent to Athena, this is now updated to check the entire query string.

N.B. `position_gps_date` appears to have changed to `position_recorded_date`