### PR TITLE
Check the query sent to Athena in GET /device-activations/{id}

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/fixtures/queries/AthenaQueries.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/fixtures/queries/AthenaQueries.kt
@@ -1,6 +1,19 @@
 package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.fixtures.queries
 
 object AthenaQueries {
+  val SelectDeviceActivationById = """
+    SELECT 
+      device_activations.device_activation_id, 
+      device_activations.device_id, 
+      device_activations.person_id, 
+      device_activations.device_activation_date, 
+      device_activations.device_deactivation_date 
+    FROM 
+      device_activations
+    WHERE 
+      device_activations.device_activation_id = ?
+  """.trimIndent().replace("\\s+".toRegex(), " ")
+
   val SelectPositionsByDeviceActivationId = """
     SELECT 
       position.position_id,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/resource/DeviceActivationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/resource/DeviceActivationControllerTest.kt
@@ -98,6 +98,12 @@ class DeviceActivationControllerTest : IntegrationTestBase() {
           orderEnd = "",
         ),
       )
+
+      // Check that the query sent to Athena was correct
+      verifyAthenaStartQueryExecutionWithQuery(
+        AthenaQueries.SelectDeviceActivationById,
+        listOf("1"),
+      )
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/deviceActivation/GetDeviceActivationByIdQueryBuilderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/deviceActivation/GetDeviceActivationByIdQueryBuilderTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.reposi
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.fixtures.queries.AthenaQueries
 
 class GetDeviceActivationByIdQueryBuilderTest {
   @Test
@@ -12,18 +13,7 @@ class GetDeviceActivationByIdQueryBuilderTest {
     ).build()
 
     assertThat(query.queryString).isEqualTo(
-      """
-      SELECT 
-        device_activations.device_activation_id, 
-        device_activations.device_id, 
-        device_activations.person_id, 
-        device_activations.device_activation_date, 
-        device_activations.device_deactivation_date 
-      FROM 
-        device_activations
-      WHERE 
-        device_activations.device_activation_id = ?
-      """.trimIndent().replace("\\s+".toRegex(), " "),
+      AthenaQueries.SelectDeviceActivationById,
     )
     assertThat(query.parameters).isEqualTo(listOf("0"))
   }


### PR DESCRIPTION
Adds an extra test that the built query is actually sent to Athena (wiremock).