### PR TITLE
Support batch id suffixes

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/crimeBatch/CrimeBatchCsvService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/crimeBatch/CrimeBatchCsvService.kt
@@ -126,7 +126,7 @@ class CrimeBatchCsvService {
     }
 
     // Batch id pattern validity
-    val regex = Regex("^${policeForce.code}(\\d{8})(-(\\d|[RAra]))?")
+    val regex = Regex("^${policeForce.code}(\\d{8})(-\\d)?(-[RAra])?")
     val match = regex.find(parsed.value) ?: return FieldValidationResult(
       errorType = CrimeBatchEmailAttachmentIngestionErrorType.INVALID_BATCH_ID_FORMAT,
       field = fieldName,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/crimeBatch/CrimeBatchCsvService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/crimeBatch/CrimeBatchCsvService.kt
@@ -126,7 +126,7 @@ class CrimeBatchCsvService {
     }
 
     // Batch id pattern validity
-    val regex = Regex("^${policeForce.code}(\\d{8})(-(\\d+|[RAra]))?")
+    val regex = Regex("^${policeForce.code}(\\d{8})(-(\\d|[RAra]))?")
     val match = regex.find(parsed.value) ?: return FieldValidationResult(
       errorType = CrimeBatchEmailAttachmentIngestionErrorType.INVALID_BATCH_ID_FORMAT,
       field = fieldName,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/crimeBatch/CrimeBatchCsvService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/crimeBatch/CrimeBatchCsvService.kt
@@ -126,7 +126,7 @@ class CrimeBatchCsvService {
     }
 
     // Batch id pattern validity
-    val regex = Regex("^${policeForce.code}(\\d{8})")
+    val regex = Regex("^${policeForce.code}(\\d{8})(-(\\d+|[RAra]))?")
     val match = regex.find(parsed.value) ?: return FieldValidationResult(
       errorType = CrimeBatchEmailAttachmentIngestionErrorType.INVALID_BATCH_ID_FORMAT,
       field = fieldName,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/crimeBatch/CrimeBatchCsvServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/crimeBatch/CrimeBatchCsvServiceTest.kt
@@ -226,6 +226,18 @@ class CrimeBatchCsvServiceTest {
     assertThat(parseResult.recordCount).isEqualTo(1)
   }
 
+  @ParameterizedTest(name = "it should parse valid batch id - {0}")
+  @MethodSource("validBatchIds")
+  fun `it should parse all valid batch ids`(batchId: String) {
+    val crimeData = createCsvRow(batchId = batchId).byteInputStream()
+    val parseResult = service.parseCsvFile(crimeData)
+
+    assertThat(parseResult.records).hasSize(1)
+    assertThat(parseResult.records[0].batchId).isEqualTo(batchId)
+    assertThat(parseResult.errors).hasSize(0)
+    assertThat(parseResult.recordCount).isEqualTo(1)
+  }
+
   @Test
   fun `it should not parse an invalid date in batch ID`() {
     val crimeData = createCsvRow(batchId = "MPS20253001").byteInputStream()
@@ -537,6 +549,12 @@ class CrimeBatchCsvServiceTest {
       Arguments.of("", "", "50", "3", "longitude", CrimeBatchEmailAttachmentIngestionErrorType.INVALID_LOCATION_DATA_RANGE, "3.0"),
       Arguments.of("", "", "", "1", "longitude", CrimeBatchEmailAttachmentIngestionErrorType.DEPENDENT_LOCATION_DATA, "1"),
       Arguments.of("", "", "", "", null, CrimeBatchEmailAttachmentIngestionErrorType.MISSING_LOCATION_DATA, null),
+    )
+
+    @JvmStatic
+    fun validBatchIds() = listOf(
+      Arguments.of("AVS20250101-1"),
+      Arguments.of("AVS20250101-R")
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/crimeBatch/CrimeBatchCsvServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/crimeBatch/CrimeBatchCsvServiceTest.kt
@@ -558,7 +558,7 @@ class CrimeBatchCsvServiceTest {
       Arguments.of("AVS20250101-R"),
       Arguments.of("AVS20250101-r"),
       Arguments.of("AVS20250101-A"),
-      Arguments.of("AVS20250101-a")
+      Arguments.of("AVS20250101-a"),
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/crimeBatch/CrimeBatchCsvServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/crimeBatch/CrimeBatchCsvServiceTest.kt
@@ -559,6 +559,8 @@ class CrimeBatchCsvServiceTest {
       Arguments.of("AVS20250101-r"),
       Arguments.of("AVS20250101-A"),
       Arguments.of("AVS20250101-a"),
+      Arguments.of("AVS20250101-1-R"),
+      Arguments.of("AVS20250101-1-A"),
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/crimeBatch/CrimeBatchCsvServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/crimeBatch/CrimeBatchCsvServiceTest.kt
@@ -229,7 +229,7 @@ class CrimeBatchCsvServiceTest {
   @ParameterizedTest(name = "it should parse valid batch id - {0}")
   @MethodSource("validBatchIds")
   fun `it should parse all valid batch ids`(batchId: String) {
-    val crimeData = createCsvRow(batchId = batchId).byteInputStream()
+    val crimeData = createCsvRow(batchId = batchId, policeForce = PoliceForce.AVON_AND_SOMERSET.identifier).byteInputStream()
     val parseResult = service.parseCsvFile(crimeData)
 
     assertThat(parseResult.records).hasSize(1)
@@ -553,8 +553,12 @@ class CrimeBatchCsvServiceTest {
 
     @JvmStatic
     fun validBatchIds() = listOf(
+      Arguments.of("AVS20250101"),
       Arguments.of("AVS20250101-1"),
-      Arguments.of("AVS20250101-R")
+      Arguments.of("AVS20250101-R"),
+      Arguments.of("AVS20250101-r"),
+      Arguments.of("AVS20250101-A"),
+      Arguments.of("AVS20250101-a")
     )
   }
 }


### PR DESCRIPTION
Batch IDs sometimes contain suffixes, currently they would fail validation. This changes updates the batch id regex to support all known suffixes.

## Numeric suffixes

- Police forces such as the Met split their daily crime data into three submission and append a numeric suffix to the end of the batch id (e.g. `MPS20250101-1`, `MPS20250101-2`).
- The Met are the only PFA I'm aware of that do this and typically send three batches a day. The regex has been updated to support a single digit numeric suffix but can be extended to support two or more digits if necessary. e.g. 
 
```diff
- "^${policeForce.code}(\\d{8})(-\\d)?(-[RAra])?"
+ "^${policeForce.code}(\\d{8})(-\\d{1,2})?(-[RAra])?"
```

## Resubmission suffixes

- Police forces may resubmit batches if they contained crimes that failed validation. When this happens they append a `-R` or `-A`. I'm not sure whether this is uppercase or lower case so I've supported both. 

## Numeric & Resubmission

- When a batch id with a numeric suffix gets resubmitted, the batch id will have both a numeric suffix and a resubmission suffix (e.g. `-1-R`).