### PR TITLE
Update crime version updates text when crime window is changed

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/model/enums/CrimeVersionFieldName.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/model/enums/CrimeVersionFieldName.kt
@@ -13,7 +13,7 @@ enum class CrimeVersionFieldName(val value: String) {
 
   fun groupLabel(): String? = when (this) {
     EASTING, NORTHING, LATITUDE, LONGITUDE -> "Crime location"
-    CRIME_DATE_TIME_FROM, CRIME_DATE_TIME_TO -> "Crime date"
+    CRIME_DATE_TIME_FROM, CRIME_DATE_TIME_TO -> "Crime window"
     else -> null
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/resource/CrimeVersionControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/resource/CrimeVersionControllerTest.kt
@@ -475,6 +475,7 @@ class CrimeVersionControllerTest : IntegrationTestBase() {
           withCrimeVersionUpdate()
           withCrimeVersionUpdate(fieldName = CrimeVersionFieldName.LATITUDE)
           withCrimeVersionUpdate(fieldName = CrimeVersionFieldName.LONGITUDE)
+          withCrimeVersionUpdate(fieldName = CrimeVersionFieldName.CRIME_DATE_TIME_TO)
         }
       }
 

--- a/src/test/resources/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/resource/get-crime-versions-multiple-derived-response.json
+++ b/src/test/resources/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/resource/get-crime-versions-multiple-derived-response.json
@@ -10,7 +10,7 @@
       "ingestionDateTime": "2025-10-31T04:03:01",
       "matched": false,
       "versionLabel": "Latest version",
-      "updates": "Crime location, Crime type"
+      "updates": "Crime location, Crime window, Crime type"
     },
     {
       "crimeVersionId": "cccccccc-cccc-cccc-cccc-cccccccccccc",


### PR DESCRIPTION
During the last team day, we decided to use "Crime window" rather than "Crime date" to represent that the either `crimeDateTimeFrom` or `crimeDateTimeTo` had changed. 

This is to reduce any ambiguity that might be caused by the crime window changing within the same day or across many days. For example, saying the crime date had changed could be misinterpreted if the date stayed the same but the time component changed. Similarly it could be misinterpreted if the crime window spanned two days (e.g. overnight). 