### PR TITLE
Update role usage to match actual client roles

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/resource/CrimeVersionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/resource/CrimeVersionController.kt
@@ -22,7 +22,7 @@ import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.service
 import java.util.UUID
 
 @RestController
-@PreAuthorize("hasAnyAuthority('ROLE_EM_CRIME_MATCHING_GENERAL_RO')")
+@PreAuthorize("hasAnyAuthority('ROLE_EM_CRIME_MATCHING__CRIMES__RO')")
 @RequestMapping("/crime-versions", produces = ["application/json"])
 class CrimeVersionController(
   private val crimeVersionService: CrimeVersionService,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/resource/deviceActivation/DeviceActivationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/resource/deviceActivation/DeviceActivationController.kt
@@ -16,7 +16,7 @@ import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.service
 import java.time.ZonedDateTime
 
 @RestController
-@PreAuthorize("hasAnyAuthority('ROLE_EM_CRIME_MATCHING_GENERAL_RO')")
+@PreAuthorize("hasAnyAuthority('ROLE_EM_CRIME_MATCHING__DEVICE_ACTIVATIONS__RO')")
 @RequestMapping("/device-activations", produces = ["application/json"])
 class DeviceActivationController(
   private val deviceActivationService: DeviceActivationService,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/resource/person/PersonController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/resource/person/PersonController.kt
@@ -18,7 +18,7 @@ import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.dto.Res
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.service.person.PersonService
 
 @RestController
-@PreAuthorize("hasAnyAuthority('ROLE_EM_CRIME_MATCHING_GENERAL_RO')")
+@PreAuthorize("hasAnyAuthority('ROLE_EM_CRIME_MATCHING__CASELOAD__RO')")
 @RequestMapping("/persons", produces = ["application/json"])
 class PersonController(
   val personService: PersonService,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/IntegrationTestBase.kt
@@ -89,7 +89,7 @@ abstract class IntegrationTestBase {
 
   internal fun setAuthorisation(
     username: String? = "AUTH_ADM",
-    roles: List<String> = listOf("ROLE_EM_CRIME_MATCHING_GENERAL_RO"),
+    roles: List<String> = emptyList(),
     scopes: List<String> = listOf("read"),
   ): (HttpHeaders) -> Unit = jwtAuthHelper.setAuthorisationHeader(username = username, scope = scopes, roles = roles)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/resource/CrimeVersionControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/resource/CrimeVersionControllerTest.kt
@@ -57,7 +57,7 @@ class CrimeVersionControllerTest : IntegrationTestBase() {
     fun `it should return an empty result when no crime versions exist`() {
       val body = webTestClient.get()
         .uri("/crime-versions?crimeRef=CRI")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__CRIMES__RO")))
         .exchange()
         .expectStatus()
         .isOk
@@ -141,7 +141,7 @@ class CrimeVersionControllerTest : IntegrationTestBase() {
 
       val body = webTestClient.get()
         .uri("/crime-versions?crimeRef=$crimeRef")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__CRIMES__RO")))
         .exchange()
         .expectStatus()
         .isOk
@@ -172,7 +172,7 @@ class CrimeVersionControllerTest : IntegrationTestBase() {
 
       webTestClient.get()
         .uri("/crime-versions?crimeRef=$crimeRef")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__CRIMES__RO")))
         .exchange()
         .expectStatus()
         .isOk
@@ -196,7 +196,7 @@ class CrimeVersionControllerTest : IntegrationTestBase() {
 
       webTestClient.get()
         .uri("/crime-versions?crimeRef=$crimeRef")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__CRIMES__RO")))
         .exchange()
         .expectStatus()
         .isOk
@@ -256,7 +256,7 @@ class CrimeVersionControllerTest : IntegrationTestBase() {
 
       val body = webTestClient.get()
         .uri("/crime-versions?crimeRef=$crimeRef")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__CRIMES__RO")))
         .exchange()
         .expectStatus()
         .isOk
@@ -300,7 +300,7 @@ class CrimeVersionControllerTest : IntegrationTestBase() {
 
       val body = webTestClient.get()
         .uri("/crime-versions?crimeRef=$crimeRef")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__CRIMES__RO")))
         .exchange()
         .expectStatus()
         .isOk
@@ -360,7 +360,7 @@ class CrimeVersionControllerTest : IntegrationTestBase() {
 
       val body = webTestClient.get()
         .uri("/crime-versions?crimeRef=$crimeRef&page=1&pageSize=1")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__CRIMES__RO")))
         .exchange()
         .expectStatus()
         .isOk
@@ -481,7 +481,7 @@ class CrimeVersionControllerTest : IntegrationTestBase() {
 
       val body = webTestClient.get()
         .uri("/crime-versions?crimeRef=$crimeRef")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__CRIMES__RO")))
         .exchange()
         .expectStatus()
         .isOk
@@ -524,7 +524,7 @@ class CrimeVersionControllerTest : IntegrationTestBase() {
       val id = UUID.randomUUID()
       webTestClient.get()
         .uri("/crime-versions/$id")
-        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING_GENERAL_RO")))
+        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__CRIMES__RO")))
         .exchange()
         .expectStatus()
         .isNotFound
@@ -542,7 +542,7 @@ class CrimeVersionControllerTest : IntegrationTestBase() {
 
       val body = webTestClient.get()
         .uri("/crime-versions/$versionId")
-        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING_GENERAL_RO")))
+        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__CRIMES__RO")))
         .exchange()
         .expectStatus()
         .isOk
@@ -571,7 +571,7 @@ class CrimeVersionControllerTest : IntegrationTestBase() {
 
       val body = webTestClient.get()
         .uri("/crime-versions/$version2")
-        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING_GENERAL_RO")))
+        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__CRIMES__RO")))
         .exchange()
         .expectStatus()
         .isOk
@@ -605,7 +605,7 @@ class CrimeVersionControllerTest : IntegrationTestBase() {
 
       val body = webTestClient.get()
         .uri("/crime-versions/$version2")
-        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING_GENERAL_RO")))
+        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__CRIMES__RO")))
         .exchange()
         .expectStatus()
         .isOk
@@ -636,7 +636,7 @@ class CrimeVersionControllerTest : IntegrationTestBase() {
 
       val body = webTestClient.get()
         .uri("/crime-versions/$version2")
-        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING_GENERAL_RO")))
+        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__CRIMES__RO")))
         .exchange()
         .expectStatus()
         .isOk
@@ -667,7 +667,7 @@ class CrimeVersionControllerTest : IntegrationTestBase() {
 
       val body = webTestClient.get()
         .uri("/crime-versions/$versionId")
-        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING_GENERAL_RO")))
+        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__CRIMES__RO")))
         .exchange()
         .expectStatus()
         .isOk
@@ -702,7 +702,7 @@ class CrimeVersionControllerTest : IntegrationTestBase() {
 
       val body = webTestClient.get()
         .uri("/crime-versions/$versionId")
-        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING_GENERAL_RO")))
+        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__CRIMES__RO")))
         .exchange()
         .expectStatus()
         .isOk
@@ -728,7 +728,7 @@ class CrimeVersionControllerTest : IntegrationTestBase() {
 
       val body = webTestClient.get()
         .uri("/crime-versions/$versionId")
-        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING_GENERAL_RO")))
+        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__CRIMES__RO")))
         .exchange()
         .expectStatus()
         .isOk

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/resource/DeviceActivationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/resource/DeviceActivationControllerTest.kt
@@ -33,7 +33,7 @@ class DeviceActivationControllerTest : IntegrationTestBase() {
     fun `it should return a BAD_REQUEST if param is not a number`() {
       val result = webTestClient.get()
         .uri("/device-activations/abc")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__DEVICE_ACTIVATIONS__RO")))
         .exchange()
         .expectStatus()
         .isBadRequest
@@ -61,7 +61,7 @@ class DeviceActivationControllerTest : IntegrationTestBase() {
 
       webTestClient.get()
         .uri("/device-activations/1")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__DEVICE_ACTIVATIONS__RO")))
         .exchange()
         .expectStatus()
         .isNotFound
@@ -78,7 +78,7 @@ class DeviceActivationControllerTest : IntegrationTestBase() {
 
       val result = webTestClient.get()
         .uri("/device-activations/1")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__DEVICE_ACTIVATIONS__RO")))
         .exchange()
         .expectStatus()
         .isOk
@@ -117,7 +117,7 @@ class DeviceActivationControllerTest : IntegrationTestBase() {
 
       val result = webTestClient.get()
         .uri("/device-activations/1")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__DEVICE_ACTIVATIONS__RO")))
         .exchange()
         .expectStatus()
         .isOk
@@ -150,14 +150,14 @@ class DeviceActivationControllerTest : IntegrationTestBase() {
 
       webTestClient.get()
         .uri("/device-activations/1")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__DEVICE_ACTIVATIONS__RO")))
         .exchange()
         .expectStatus()
         .isOk
 
       webTestClient.get()
         .uri("/device-activations/1")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__DEVICE_ACTIVATIONS__RO")))
         .exchange()
         .expectStatus()
         .isOk
@@ -176,7 +176,7 @@ class DeviceActivationControllerTest : IntegrationTestBase() {
 
       val response = webTestClient.get()
         .uri("/device-activations/1")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__DEVICE_ACTIVATIONS__RO")))
         .exchange()
         .expectStatus()
         .is5xxServerError
@@ -204,7 +204,7 @@ class DeviceActivationControllerTest : IntegrationTestBase() {
 
       webTestClient.get()
         .uri("/device-activations/1")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__DEVICE_ACTIVATIONS__RO")))
         .exchange()
         .expectStatus()
         .isOk
@@ -234,7 +234,7 @@ class DeviceActivationControllerTest : IntegrationTestBase() {
     fun `it should return a BAD_REQUEST if param is not a number`() {
       val result = webTestClient.get()
         .uri("/device-activations/abc/positions")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__DEVICE_ACTIVATIONS__RO")))
         .exchange()
         .expectStatus()
         .isBadRequest
@@ -262,7 +262,7 @@ class DeviceActivationControllerTest : IntegrationTestBase() {
 
       val result = webTestClient.get()
         .uri("/device-activations/1/positions")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__DEVICE_ACTIVATIONS__RO")))
         .exchange()
         .expectStatus()
         .isOk
@@ -284,7 +284,7 @@ class DeviceActivationControllerTest : IntegrationTestBase() {
 
       val result = webTestClient.get()
         .uri("/device-activations/1/positions")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__DEVICE_ACTIVATIONS__RO")))
         .exchange()
         .expectStatus()
         .isOk
@@ -349,7 +349,7 @@ class DeviceActivationControllerTest : IntegrationTestBase() {
 
       val result = webTestClient.get()
         .uri("/device-activations/1/positions?geolocationMechanism=abc")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__DEVICE_ACTIVATIONS__RO")))
         .exchange()
         .expectStatus()
         .isBadRequest
@@ -377,7 +377,7 @@ class DeviceActivationControllerTest : IntegrationTestBase() {
 
       val result = webTestClient.get()
         .uri("/device-activations/1/positions?from=abc")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__DEVICE_ACTIVATIONS__RO")))
         .exchange()
         .expectStatus()
         .isBadRequest
@@ -405,7 +405,7 @@ class DeviceActivationControllerTest : IntegrationTestBase() {
 
       val result = webTestClient.get()
         .uri("/device-activations/1/positions?to=abc")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__DEVICE_ACTIVATIONS__RO")))
         .exchange()
         .expectStatus()
         .isBadRequest
@@ -433,7 +433,7 @@ class DeviceActivationControllerTest : IntegrationTestBase() {
 
       webTestClient.get()
         .uri("/device-activations/1/positions?geolocationMechanism=GPS")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__DEVICE_ACTIVATIONS__RO")))
         .exchange()
         .expectStatus()
         .isOk
@@ -459,7 +459,7 @@ class DeviceActivationControllerTest : IntegrationTestBase() {
 
       webTestClient.get()
         .uri("/device-activations/1/positions?from=2025-01-01T00:00:00Z")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__DEVICE_ACTIVATIONS__RO")))
         .exchange()
         .expectStatus()
         .isOk
@@ -485,7 +485,7 @@ class DeviceActivationControllerTest : IntegrationTestBase() {
 
       webTestClient.get()
         .uri("/device-activations/1/positions?to=2025-01-01T00:00:00Z")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__DEVICE_ACTIVATIONS__RO")))
         .exchange()
         .expectStatus()
         .isOk
@@ -511,14 +511,14 @@ class DeviceActivationControllerTest : IntegrationTestBase() {
 
       webTestClient.get()
         .uri("/device-activations/1/positions")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__DEVICE_ACTIVATIONS__RO")))
         .exchange()
         .expectStatus()
         .isOk
 
       webTestClient.get()
         .uri("/device-activations/1/positions")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__DEVICE_ACTIVATIONS__RO")))
         .exchange()
         .expectStatus()
         .isOk
@@ -537,7 +537,7 @@ class DeviceActivationControllerTest : IntegrationTestBase() {
 
       val response = webTestClient.get()
         .uri("/device-activations/1/positions")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__DEVICE_ACTIVATIONS__RO")))
         .exchange()
         .expectStatus()
         .is5xxServerError
@@ -565,7 +565,7 @@ class DeviceActivationControllerTest : IntegrationTestBase() {
 
       webTestClient.get()
         .uri("/device-activations/1/positions")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__DEVICE_ACTIVATIONS__RO")))
         .exchange()
         .expectStatus()
         .isOk

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/resource/PersonControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/resource/PersonControllerTest.kt
@@ -31,7 +31,7 @@ class PersonControllerTest : IntegrationTestBase() {
 
       val result = webTestClient.get()
         .uri("/persons?name=name")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__CASELOAD__RO")))
         .exchange()
         .expectStatus()
         .isOk
@@ -71,7 +71,7 @@ class PersonControllerTest : IntegrationTestBase() {
     fun `it should fail with bad request when invalid criteria fields are passed`() {
       webTestClient.get()
         .uri("/persons")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__CASELOAD__RO")))
         .exchange()
         .expectStatus()
         .isBadRequest
@@ -83,7 +83,7 @@ class PersonControllerTest : IntegrationTestBase() {
 
       val response = webTestClient.get()
         .uri("/persons?name=name")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__CASELOAD__RO")))
         .exchange()
         .expectStatus()
         .is5xxServerError
@@ -115,7 +115,7 @@ class PersonControllerTest : IntegrationTestBase() {
 
       webTestClient.get()
         .uri("/persons/1")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__CASELOAD__RO")))
         .exchange()
         .expectStatus()
         .isNotFound
@@ -132,7 +132,7 @@ class PersonControllerTest : IntegrationTestBase() {
 
       val result = webTestClient.get()
         .uri("/persons/1")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__CASELOAD__RO")))
         .exchange()
         .expectStatus()
         .isOk
@@ -165,14 +165,14 @@ class PersonControllerTest : IntegrationTestBase() {
 
       webTestClient.get()
         .uri("/persons/1")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__CASELOAD__RO")))
         .exchange()
         .expectStatus()
         .isOk
 
       webTestClient.get()
         .uri("/persons/1")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__CASELOAD__RO")))
         .exchange()
         .expectStatus()
         .isOk
@@ -191,7 +191,7 @@ class PersonControllerTest : IntegrationTestBase() {
 
       val response = webTestClient.get()
         .uri("/persons/1")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__CASELOAD__RO")))
         .exchange()
         .expectStatus()
         .is5xxServerError
@@ -219,7 +219,7 @@ class PersonControllerTest : IntegrationTestBase() {
 
       webTestClient.get()
         .uri("/persons/1")
-        .headers(setAuthorisation())
+        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__CASELOAD__RO")))
         .exchange()
         .expectStatus()
         .isOk


### PR DESCRIPTION
Updates roles to remove generic and poorly named `ROLE_EM_CRIME_MATCHING_GENERAL_RO`.