### PR TITLE
Update the PersonResultSetExtractor to match the GetPersonsQueryBuilder

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/person/PersonResultSetExtractor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/person/PersonResultSetExtractor.kt
@@ -30,14 +30,14 @@ class PersonResultSetExtractor : AthenaResultSetExtractor<Person> {
         )
       }
 
-      if (row.size == 15) {
+      if (row.size == 14) {
         val deviceActivation = DeviceActivation(
-          deviceActivationId = row[12].toLong(),
+          deviceActivationId = row[11].toLong(),
           deviceId = row[10].toLong(),
           deviceName = "",
           personId = row[0],
-          deviceActivationDate = LocalDateTime.parse(row[13], formatter),
-          deviceDeactivationDate = nullableLocalDateTime(row[14]),
+          deviceActivationDate = LocalDateTime.parse(row[12], formatter),
+          deviceDeactivationDate = nullableLocalDateTime(row[13]),
           orderStart = "",
           orderEnd = "",
         )

--- a/src/test/resources/__files/athenaResponses/person.empty.success.json
+++ b/src/test/resources/__files/athenaResponses/person.empty.success.json
@@ -137,18 +137,6 @@
         {
           "CaseSensitive": false,
           "CatalogName": "hive",
-          "Label": "person_id",
-          "Name": "person_id",
-          "Nullable": "UNKNOWN",
-          "Precision": 2147483647,
-          "Scale": 0,
-          "SchemaName": "",
-          "TableName": "",
-          "Type": "bigint"
-        },
-        {
-          "CaseSensitive": false,
-          "CatalogName": "hive",
           "Label": "device_activation_id",
           "Name": "device_activation_id",
           "Nullable": "UNKNOWN",
@@ -219,9 +207,6 @@
           },
           {
             "VarCharValue": "device_id"
-          },
-          {
-            "VarCharValue": "person_id"
           },
           {
             "VarCharValue": "device_activation_id"

--- a/src/test/resources/__files/athenaResponses/persons.device-activations.success.json
+++ b/src/test/resources/__files/athenaResponses/persons.device-activations.success.json
@@ -137,18 +137,6 @@
         {
           "CaseSensitive": false,
           "CatalogName": "hive",
-          "Label": "person_id",
-          "Name": "person_id",
-          "Nullable": "UNKNOWN",
-          "Precision": 2147483647,
-          "Scale": 0,
-          "SchemaName": "",
-          "TableName": "",
-          "Type": "bigint"
-        },
-        {
-          "CaseSensitive": false,
-          "CatalogName": "hive",
           "Label": "device_activation_id",
           "Name": "device_activation_id",
           "Nullable": "UNKNOWN",
@@ -221,9 +209,6 @@
             "VarCharValue": "device_id"
           },
           {
-            "VarCharValue": "person_id"
-          },
-          {
             "VarCharValue": "device_activation_id"
           },
           {
@@ -268,9 +253,6 @@
           },
           {
             "VarCharValue": "12345"
-          },
-          {
-            "VarCharValue": "56789"
           },
           {
             "VarCharValue": "54321"


### PR DESCRIPTION
The [GetPersonsQueryBuilder](https://github.com/ministryofjustice/hmpps-electronic-monitoring-crime-matching-api/blob/533115253853d48cbf9631c0f06cd1043a203f35/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/person/GetPersonsQueryBuilder.kt) returns 14 columns.

The [PersonResultSetExtractor](https://github.com/ministryofjustice/hmpps-electronic-monitoring-crime-matching-api/blob/533115253853d48cbf9631c0f06cd1043a203f35/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/person/PersonResultSetExtractor.kt) expects 15 columns.

The difference seems to be the `personId` column which we decided to use the `unique_device_wearer_id` for rather than using the `person_id` column in the `device activation` table.