### PR TITLE
Deserialise uniqueDeviceWearerId correctly in device activation queries

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/dto/DeviceActivationResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/dto/DeviceActivationResponse.kt
@@ -16,7 +16,7 @@ data class DeviceActivationResponse(
     deviceActivationId = deviceActivation.deviceActivationId,
     deviceId = deviceActivation.deviceId,
     deviceName = deviceActivation.deviceName,
-    personId = deviceActivation.personId,
+    personId = deviceActivation.uniqueDeviceWearerId,
     deviceActivationDate = deviceActivation.deviceActivationDate.toString(),
     deviceDeactivationDate = deviceActivation.deviceDeactivationDate?.toString(),
     orderStart = deviceActivation.orderStart,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/model/entity/DeviceActivation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/model/entity/DeviceActivation.kt
@@ -10,7 +10,7 @@ data class DeviceActivation(
 
   val deviceName: String = "",
 
-  val personId: String,
+  val uniqueDeviceWearerId: String,
 
   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss[.[SSSSSS][SSS]]")
   val deviceActivationDate: LocalDateTime,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/person/PersonResultSetExtractor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/person/PersonResultSetExtractor.kt
@@ -35,7 +35,7 @@ class PersonResultSetExtractor : AthenaResultSetExtractor<Person> {
           deviceActivationId = row[11].toLong(),
           deviceId = row[10].toLong(),
           deviceName = "",
-          personId = row[0],
+          uniqueDeviceWearerId = row[0],
           deviceActivationDate = LocalDateTime.parse(row[12], formatter),
           deviceDeactivationDate = nullableLocalDateTime(row[13]),
           orderStart = "",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/fixtures/queries/AthenaQueries.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/fixtures/queries/AthenaQueries.kt
@@ -3,11 +3,11 @@ package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.fixtur
 object AthenaQueries {
   val SelectDeviceActivationById = """
     SELECT 
-      device_activations.device_activation_id, 
-      device_activations.device_id, 
-      caseload.unique_device_wearer_id, 
-      device_activations.device_activation_date, 
-      device_activations.device_deactivation_date 
+      device_activations.device_activation_id,
+      device_activations.device_id,
+      caseload.unique_device_wearer_id,
+      device_activations.device_activation_date,
+      device_activations.device_deactivation_date
     FROM 
       device_activations
     INNER JOIN 
@@ -20,7 +20,7 @@ object AthenaQueries {
     SELECT
       caseload.unique_device_wearer_id,
       caseload.first_name,
-      caseload.last_name, 
+      caseload.last_name,
       caseload.nomis_id,
       caseload.pnc_id,
       caseload.date_of_birth,
@@ -37,9 +37,9 @@ object AthenaQueries {
   val SelectPersonsByNameLike = """
     SELECT 
       caseload.unique_device_wearer_id, 
-      caseload.first_name, 
-      caseload.last_name, 
-      caseload.nomis_id, 
+      caseload.first_name,
+      caseload.last_name,
+      caseload.nomis_id,
       caseload.pnc_id,
       caseload.date_of_birth,
       caseload.responsible_officer_name,
@@ -59,20 +59,20 @@ object AthenaQueries {
 
   val SelectPersonsByNomisIdLike = """
     SELECT 
-      caseload.unique_device_wearer_id, 
-      caseload.first_name, 
-      caseload.last_name, 
-      caseload.nomis_id, 
+      caseload.unique_device_wearer_id,
+      caseload.first_name,
+      caseload.last_name,
+      caseload.nomis_id,
       caseload.pnc_id,
       caseload.date_of_birth,
       caseload.responsible_officer_name,
-      caseload.postcode, 
-      caseload.city_or_town, 
-      caseload.house_number_and_street_name, 
+      caseload.postcode,
+      caseload.city_or_town,
+      caseload.house_number_and_street_name,
       device_activations.device_id,
-      device_activations.device_activation_id, 
-      device_activations.device_activation_date, 
-      device_activations.device_deactivation_date 
+      device_activations.device_activation_id,
+      device_activations.device_activation_date,
+      device_activations.device_deactivation_date
     FROM 
       caseload 
     INNER JOIN 
@@ -82,20 +82,20 @@ object AthenaQueries {
 
   val SelectPersonsByDeviceIdLike = """
     SELECT 
-      caseload.unique_device_wearer_id, 
-      caseload.first_name, 
-      caseload.last_name, 
-      caseload.nomis_id, 
+      caseload.unique_device_wearer_id,
+      caseload.first_name,
+      caseload.last_name,
+      caseload.nomis_id,
       caseload.pnc_id,
       caseload.date_of_birth,
       caseload.responsible_officer_name,
-      caseload.postcode, 
-      caseload.city_or_town, 
-      caseload.house_number_and_street_name, 
+      caseload.postcode,
+      caseload.city_or_town,
+      caseload.house_number_and_street_name,
       device_activations.device_id,
-      device_activations.device_activation_id, 
-      device_activations.device_activation_date, 
-      device_activations.device_deactivation_date 
+      device_activations.device_activation_id,
+      device_activations.device_activation_date,
+      device_activations.device_deactivation_date
     FROM 
       caseload 
     INNER JOIN 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/person/PersonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/person/PersonServiceTest.kt
@@ -49,7 +49,7 @@ class PersonServiceTest {
               deviceActivationId = 54321,
               deviceId = 12345,
               deviceName = "",
-              personId = "1",
+              uniqueDeviceWearerId = "1",
               deviceActivationDate = LocalDateTime.of(2021, 1, 1, 1, 1),
               deviceDeactivationDate = null,
               orderStart = "",

--- a/src/test/resources/__files/athenaResponses/device-activation.active.success.json
+++ b/src/test/resources/__files/athenaResponses/device-activation.active.success.json
@@ -29,8 +29,8 @@
         {
           "CaseSensitive": false,
           "CatalogName": "hive",
-          "Label": "person_id",
-          "Name": "person_id",
+          "Label": "unique_device_wearer_id",
+          "Name": "unique_device_wearer_id",
           "Nullable": "UNKNOWN",
           "Precision": 2147483647,
           "Scale": 0,
@@ -74,7 +74,7 @@
             "VarCharValue": "device_id"
           },
           {
-            "VarCharValue": "person_id"
+            "VarCharValue": "unique_device_wearer_id"
           },
           {
             "VarCharValue": "device_activation_date"

--- a/src/test/resources/__files/athenaResponses/device-activation.empty.success.json
+++ b/src/test/resources/__files/athenaResponses/device-activation.empty.success.json
@@ -29,8 +29,8 @@
         {
           "CaseSensitive": false,
           "CatalogName": "hive",
-          "Label": "person_id",
-          "Name": "person_id",
+          "Label": "unique_device_wearer_id",
+          "Name": "unique_device_wearer_id",
           "Nullable": "UNKNOWN",
           "Precision": 2147483647,
           "Scale": 0,
@@ -74,7 +74,7 @@
             "VarCharValue": "device_id"
           },
           {
-            "VarCharValue": "person_id"
+            "VarCharValue": "unique_device_wearer_id"
           },
           {
             "VarCharValue": "device_activation_date"

--- a/src/test/resources/__files/athenaResponses/device-activation.inactive.success.json
+++ b/src/test/resources/__files/athenaResponses/device-activation.inactive.success.json
@@ -29,8 +29,8 @@
         {
           "CaseSensitive": false,
           "CatalogName": "hive",
-          "Label": "person_id",
-          "Name": "person_id",
+          "Label": "unique_device_wearer_id",
+          "Name": "unique_device_wearer_id",
           "Nullable": "UNKNOWN",
           "Precision": 19,
           "Scale": 0,
@@ -74,7 +74,7 @@
             "VarCharValue": "device_id"
           },
           {
-            "VarCharValue": "person_id"
+            "VarCharValue": "unique_device_wearer_id"
           },
           {
             "VarCharValue": "device_activation_date"


### PR DESCRIPTION
When deserialising the get device activation by id query, we get this error:

```text
Instantiation of [simple type, class uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.entity.DeviceActivation] value failed for JSON property person_id due to missing (therefore NULL) value for creator parameter personId which is a non-nullable type
```

This is because the `SimpleResultSetExtractor` tries to deserialise the Athena responses by matching column names to property names. The `GetDeviceActivationByIdQueryBuilder` creates a query that returns `unique_device_wearer_id` but the `DeviceActivation` entity has a property of `personId`.

This updates the internal representation of a `DeviceActivation` to use `uniqueDeviceWearerId` but keeps `personId` in the public interface (i.e. DTO).