### PR TITLE
Only use the athena endpoint url for athena requests i.e. not STS

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/config/aws/AthenaProperties.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/config/aws/AthenaProperties.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.config.aws
 
 data class AthenaProperties(
+  val endpointUrl: String? = null,
   val role: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/config/aws/AwsConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/config/aws/AwsConfig.kt
@@ -36,8 +36,8 @@ class AwsConfig(
     val clientBuilder = AthenaClient.builder()
       .region(properties.region)
 
-    if (properties.endpointUrl != null) {
-      clientBuilder.endpointOverride(URI(properties.endpointUrl))
+    if (properties.athena.endpointUrl != null) {
+      clientBuilder.endpointOverride(URI(properties.athena.endpointUrl))
     }
 
     if (properties.athena.role != null) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -84,8 +84,8 @@ notify:
 
 aws:
   region: eu-west-2
-  endpoint-url: ${ATHENA_ENDPOINT}
   athena:
+    endpoint-url: ${ATHENA_ENDPOINT}
     role: ${ATHENA_GENERAL_IAM_ROLE}
   s3:
     bucket-name: police-emails

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -36,6 +36,7 @@ aws:
     endpoint-url: http://localhost:4566
   athena:
     role: testIAM
+    endpoint-url: http://localhost:8091
 
 spring:
   jpa:


### PR DESCRIPTION
We only want to stub Athena endpoints for the location data journey, we want to keep using the real SQS, S3 resources deployed to cloud platform for the police data ingestion.

This means we have to use the real STS endpoint.

The `AwsConfig` class was using the same `properties.endpointUrl` to create the STS client and the Athena client, which is causing the STS calls to fail (because I didn't create wiremock mappings for STS so we can continue using SQS, S3).

This adds a new `properties.athena.endpointUrl` that will only be used when creating the Athena client