### PR TITLE
Make the config map names shorter

### DIFF
--- a/helm_deploy/hmpps-electronic-monitoring-crime-matching-api/templates/wiremock.yaml
+++ b/helm_deploy/hmpps-electronic-monitoring-crime-matching-api/templates/wiremock.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.deploy_stubs }}
 {{- $mappingsGlob := "files/stubs/mappings/*" }}
-{{- $baseName := "hmpps-electronic-monitoring-crime-matching-datastore-stub-data-mappings" }}
+{{- $baseName := "datastore-stub-mappings" }}
 
 {{- range $path, $_ := $.Files.Glob $mappingsGlob }}
 {{- $fileName := base $path }}


### PR DESCRIPTION
The config map names were exceeding the limit of 63 characters causing them all to have the same name and overwrite each other.