### PR TITLE
ACR-925: Prevent crimes with a window of > 12h and <13h from being incorrectly ingested

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/crimeBatch/CrimeBatchCsvService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/crimeBatch/CrimeBatchCsvService.kt
@@ -22,7 +22,7 @@ import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeParseException
 
-private const val CRIME_DATE_WINDOW_HOURS = 12
+private val CRIME_WINDOW_MAX_DURATION = Duration.ofHours(12)
 
 @Service
 class CrimeBatchCsvService {
@@ -221,13 +221,13 @@ class CrimeBatchCsvService {
       )
     }
 
-    val crimeDateWindow = Duration.between(dateFrom, dateTo).toHours()
+    val crimeWindowDuration = Duration.between(dateFrom, dateTo)
 
-    if (crimeDateWindow > CRIME_DATE_WINDOW_HOURS) {
+    if (crimeWindowDuration > CRIME_WINDOW_MAX_DURATION) {
       return FieldValidationResult(
         errorType = CrimeBatchEmailAttachmentIngestionErrorType.CRIME_DATE_TIME_EXCEEDS_WINDOW,
         field = fieldName,
-        input = crimeDateWindow.toString(),
+        input = "${crimeWindowDuration.toHours()}h ${crimeWindowDuration.toMinutesPart()}m",
       )
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/crimeBatch/CrimeBatchCsvServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/crimeBatch/CrimeBatchCsvServiceTest.kt
@@ -362,7 +362,7 @@ class CrimeBatchCsvServiceTest {
           crimeTypeId = CrimeType.TOMV,
           errorType = CrimeBatchEmailAttachmentIngestionErrorType.CRIME_DATE_TIME_EXCEEDS_WINDOW,
           field = "dateTo",
-          value = "1416",
+          value = "1416h 0m",
         ),
       ),
     )
@@ -386,7 +386,7 @@ class CrimeBatchCsvServiceTest {
           crimeTypeId = CrimeType.TOMV,
           errorType = CrimeBatchEmailAttachmentIngestionErrorType.CRIME_DATE_TIME_EXCEEDS_WINDOW,
           field = "dateTo",
-          value = "12",
+          value = "12h 59m",
         ),
       ),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/crimeBatch/CrimeBatchCsvServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/crimeBatch/CrimeBatchCsvServiceTest.kt
@@ -346,7 +346,7 @@ class CrimeBatchCsvServiceTest {
   }
 
   @Test
-  fun `it should not parse a crime if crime date windows exceeds 12 hours`() {
+  fun `it should not parse a crime if crime window exceeds 12 hours`() {
     val crimeData = createCsvRow(
       crimeDateTimeFrom = "20250125083000",
       crimeDateTimeTo = "20250325083000",
@@ -363,6 +363,30 @@ class CrimeBatchCsvServiceTest {
           errorType = CrimeBatchEmailAttachmentIngestionErrorType.CRIME_DATE_TIME_EXCEEDS_WINDOW,
           field = "dateTo",
           value = "1416",
+        ),
+      ),
+    )
+    assertThat(parseResult.recordCount).isEqualTo(1)
+  }
+
+  @Test
+  fun `it should not parse a crime if crime window exceeds 12 hours but is less than 13 hours`() {
+    val crimeData = createCsvRow(
+      crimeDateTimeFrom = "20250125000000",
+      crimeDateTimeTo = "20250125125900",
+    ).byteInputStream()
+    val parseResult = service.parseCsvFile(crimeData)
+
+    assertThat(parseResult.records).hasSize(0)
+    assertThat(parseResult.errors).isEqualTo(
+      listOf(
+        EmailAttachmentIngestionError(
+          rowNumber = 1,
+          crimeReference = "CRI00000001",
+          crimeTypeId = CrimeType.TOMV,
+          errorType = CrimeBatchEmailAttachmentIngestionErrorType.CRIME_DATE_TIME_EXCEEDS_WINDOW,
+          field = "dateTo",
+          value = "12",
         ),
       ),
     )


### PR DESCRIPTION
Fix crime date window validation to correctly reject windows greater than 12 hours.

Previously the validation compared the truncated hour value returned by Duration.toHours(), which allowed windows of up to 12 hours 59 minutes to pass. The validation now compares Duration objects directly against the maximum allowed duration, ensuring any window greater than 12 hours is rejected. Added tests to cover the 12 hours 59 minutes bug.