### PR TITLE
Generic prometheus alerts

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -23,11 +23,14 @@ generic-service:
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:
   alertSeverity: hmpps-em-crime-matching-alerts-nonprod
+  businessHoursOnly: true
   sqsAlertsTotalMessagesThreshold: 10
   sqsAlertsOldestThreshold: 60
   sqsAlertsQueueNames:
     - hmpps-em-probation-devs-dev-email-notifications
   sqsNumberAlertQueueNames:
     - hmpps-em-probation-devs-dev-email-notifications-dlq
+  rdsAlertsDatabases:
+    cloud-platform-aa6d54b06ce132e9: "Electronic Monitoring Crime Matching API Database"
 
 deploy_stubs: false

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -28,5 +28,6 @@ generic-prometheus-alerts:
     - hmpps-em-probation-devs-dev-email-notifications-dlq
   rdsAlertsDatabases:
     cloud-platform-aa6d54b06ce132e9: "Electronic Monitoring Crime Matching API Database"
+  rdsAlertsConnectionThreshold: 65
 
 deploy_stubs: false

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -23,11 +23,7 @@ generic-service:
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:
   alertSeverity: hmpps-em-crime-matching-alerts-nonprod
-  businessHoursOnly: true
-  sqsAlertsTotalMessagesThreshold: 10
-  sqsAlertsOldestThreshold: 60
-  sqsAlertsQueueNames:
-    - hmpps-em-probation-devs-dev-email-notifications
+  sqsAlertsTotalMessagesThreshold: 1
   sqsNumberAlertQueueNames:
     - hmpps-em-probation-devs-dev-email-notifications-dlq
   rdsAlertsDatabases:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -23,5 +23,11 @@ generic-service:
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:
   alertSeverity: hmpps-em-crime-matching-alerts-nonprod
+  sqsAlertsTotalMessagesThreshold: 10
+  sqsAlertsOldestThreshold: 60
+  sqsAlertsQueueNames:
+    - hmpps-em-probation-devs-dev-email-notifications
+  sqsNumberAlertQueueNames:
+    - hmpps-em-probation-devs-dev-email-notifications-dlq
 
 deploy_stubs: false

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -26,3 +26,4 @@ generic-prometheus-alerts:
     - hmpps-em-probation-devs-preprod-email-notifications-dlq
   rdsAlertsDatabases:
     cloud-platform-3b9e8faa7849429d: "Electronic Monitoring Crime Matching API Database"
+  rdsAlertsConnectionThreshold: 65

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -21,10 +21,7 @@ generic-service:
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:
   alertSeverity: hmpps-em-crime-matching-alerts-nonprod
-  sqsAlertsTotalMessagesThreshold: 10
-  sqsAlertsOldestThreshold: 60
-  sqsAlertsQueueNames:
-    - hmpps-em-probation-devs-preprod-email-notifications
+  sqsAlertsTotalMessagesThreshold: 1
   sqsNumberAlertQueueNames:
     - hmpps-em-probation-devs-preprod-email-notifications-dlq
   rdsAlertsDatabases:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -21,3 +21,9 @@ generic-service:
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:
   alertSeverity: hmpps-em-crime-matching-alerts-nonprod
+  sqsAlertsTotalMessagesThreshold: 10
+  sqsAlertsOldestThreshold: 60
+  sqsAlertsQueueNames:
+    - hmpps-em-probation-devs-preprod-email-notifications
+  sqsNumberAlertQueueNames:
+    - hmpps-em-probation-devs-preprod-email-notifications-dlq

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -27,3 +27,5 @@ generic-prometheus-alerts:
     - hmpps-em-probation-devs-preprod-email-notifications
   sqsNumberAlertQueueNames:
     - hmpps-em-probation-devs-preprod-email-notifications-dlq
+  rdsAlertsDatabases:
+    cloud-platform-3b9e8faa7849429d: "Electronic Monitoring Crime Matching API Database"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -23,3 +23,4 @@ generic-prometheus-alerts:
     - hmpps-em-probation-devs-prod-email-notifications-dlq
   rdsAlertsDatabases:
     cloud-platform-10b776a9f85b82ac: "Electronic Monitoring Crime Matching API Database"
+  rdsAlertsConnectionThreshold: 65

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -24,3 +24,5 @@ generic-prometheus-alerts:
     - hmpps-em-probation-devs-prod-email-notifications
   sqsNumberAlertQueueNames:
     - hmpps-em-probation-devs-prod-email-notifications-dlq
+  rdsAlertsDatabases:
+    cloud-platform-10b776a9f85b82ac: "Electronic Monitoring Crime Matching API Database"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -18,10 +18,7 @@ generic-service:
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:
   alertSeverity: hmpps-em-crime-matching-alerts-prod
-  sqsAlertsTotalMessagesThreshold: 10
-  sqsAlertsOldestThreshold: 60
-  sqsAlertsQueueNames:
-    - hmpps-em-probation-devs-prod-email-notifications
+  sqsAlertsTotalMessagesThreshold: 1
   sqsNumberAlertQueueNames:
     - hmpps-em-probation-devs-prod-email-notifications-dlq
   rdsAlertsDatabases:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -18,3 +18,9 @@ generic-service:
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:
   alertSeverity: hmpps-em-crime-matching-alerts-prod
+  sqsAlertsTotalMessagesThreshold: 10
+  sqsAlertsOldestThreshold: 60
+  sqsAlertsQueueNames:
+    - hmpps-em-probation-devs-prod-email-notifications
+  sqsNumberAlertQueueNames:
+    - hmpps-em-probation-devs-prod-email-notifications-dlq


### PR DESCRIPTION
Changes:
- Added SQS number of messages alert to the email notifications dlq in all environments, this will trigger when 1 message appears on the queue
- Added RDS generic alerts for all environments, this includes triggers for high CPU usage and too many connections. The connections threshold has been set to the recommended approx 80% usage based on the current max_connections value of 79 in all environments.