### PR TITLE
ACR-909: Be more permissive for the subject line on submitted emails

### DIFF
--- a/scripts/fixtures/email-file.eml
+++ b/scripts/fixtures/email-file.eml
@@ -1,5 +1,5 @@
 From: test@email.com
-Subject: Crime Mapping Request
+Subject: Metropolitan - Crime Mapping Request - 20251015
 Date: Wed, 15 Oct 2025 13:56:58 +0000
 MIME-Version: 1.0
 X-MS-Has-Attach: yes

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/internal/EmailParserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/internal/EmailParserService.kt
@@ -41,7 +41,7 @@ class EmailParserService(
   }
 
   private fun validateMetadata(subject: String, sender: String, redirectAddress: String) {
-    if (!subject.equals("Crime Mapping Request", ignoreCase = true)) throw ValidationException("Invalid email subject")
+    if (!subject.contains("Crime Mapping Request", ignoreCase = true)) throw ValidationException("Invalid email subject")
 
     if (!redirectAddress.contains(properties.mailboxAddress, ignoreCase = true)) throw ValidationException("Invalid redirect email")
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/helper/EmailUtils.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/helper/EmailUtils.kt
@@ -17,7 +17,7 @@ fun createCsvRow(
 
 fun createEmailFile(
   csvContent: String = "test",
-  subject: String = "Crime Mapping Request",
+  subject: String = "Metropolitan - Crime Mapping Request - 20260209",
   fromAddress: String = "test@email.com",
   resentFrom: String = "<shared-mailbox@email.com>",
 ) = """
@@ -47,7 +47,7 @@ fun createEmailFile(
 
 fun createEmailFileWithoutAttachment() = """
   From: test@email.com
-  Subject: Crime Mapping Request
+  Subject: Metropolitan - Crime Mapping Request - 20251015
   Date: Wed, 15 Oct 2025 13:56:58 +0000
   X-MS-Has-Attach: no
   Resent-From: <shared-mailbox@email.com>
@@ -61,7 +61,7 @@ fun createEmailFileWithoutAttachment() = """
 
 fun createEmailFileWithMultipleAttachments() = """
   From: test@email.com
-  Subject: Crime Mapping Request
+  Subject: Metropolitan - Crime Mapping Request - 20251015
   Date: Wed, 15 Oct 2025 13:56:58 +0000
   X-MS-Has-Attach: yes
   Resent-From: <shared-mailbox@email.com>
@@ -99,7 +99,7 @@ fun createEmailFileWithMultipleAttachments() = """
 
 fun createEmailFileNoRedirect() = """
   From: test@email.com
-  Subject: Crime Mapping Request
+  Subject: Metropolitan - Crime Mapping Request - 20251015
   Date: Wed, 15 Oct 2025 13:56:58 +0000
   X-MS-Has-Attach: yes
   Content-Type: multipart/mixed;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/internal/EmailListenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/internal/EmailListenerTest.kt
@@ -148,6 +148,83 @@ class EmailListenerTest {
     }
 
     @Test
+    fun `it should successfully receive and process an email notification with a plain subject line`() {
+      val message = """
+        {
+          "receipt" : {
+            "action" : {
+              "bucketName" : "emails",
+              "objectKey" : "email-file-plain-subject"
+            }
+          }
+        }
+      """.trimIndent()
+      val messageId = UUID.randomUUID()
+      val sqsMessage = SqsMessage("Notification", message, messageId)
+
+      val csvContent = listOf(
+        createCsvRow(),
+      ).joinToString("\n")
+      val encoded = Base64.encode(csvContent.toByteArray())
+
+      val responseStream = ResponseInputStream(
+        GetObjectResponse.builder().build(),
+        createEmailFile(csvContent = encoded, subject = "Crime Mapping Request").byteInputStream(),
+      )
+
+      val crimeBatchIngestionAttempt = CrimeBatchIngestionAttempt(
+        bucket = "emails",
+        objectName = "email-file-plain-subject",
+      )
+
+      whenever(s3Service.getObject(messageId, "email-file-plain-subject", "emails")).thenReturn(responseStream)
+      whenever(crimeBatchEmailIngestionService.createCrimeBatchIngestionAttempt("emails", "email-file-plain-subject")).thenReturn(
+        crimeBatchIngestionAttempt,
+      )
+
+      val crimeBatchEmail = CrimeBatchEmail(
+        crimeBatchIngestionAttempt = crimeBatchIngestionAttempt,
+        sender = "sender",
+        originalSender = "originalSender",
+        subject = "subject",
+        sentAt = Date.from(Instant.now()),
+      )
+
+      val crimeBatchEmailAttachment = CrimeBatchEmailAttachment(
+        crimeBatchEmail = crimeBatchEmail,
+        fileName = "filename",
+        rowCount = 1,
+      )
+
+      val crimeBatch = CrimeBatch(
+        batchId = "batchId",
+        crimeBatchEmailAttachment = crimeBatchEmailAttachment,
+      )
+
+      whenever(crimeBatchEmailIngestionService.createCrimeBatchEmailAttachment(any(), any(), any())).thenReturn(
+        crimeBatchEmailAttachment,
+      )
+
+      whenever(crimeBatchService.createCrimeBatch(any(), any())).thenReturn(
+        crimeBatch,
+      )
+
+      whenever(crimeBatchEmailIngestionService.createCrimeBatchEmail(any(), any())).thenReturn(
+        CrimeBatchEmail(
+          crimeBatchIngestionAttempt = crimeBatchIngestionAttempt,
+          sender = "sender",
+          originalSender = "originalSender",
+          subject = "subject",
+          sentAt = Date.from(Instant.now()),
+        ),
+      )
+
+      assertDoesNotThrow { listener.receiveEmailNotification(sqsMessage) }
+      verify(emailNotificationService, times(1)).sendEmails(any())
+      verify(metricsService, times(1)).recordOutcome(any())
+    }
+
+    @Test
     fun `it should throw an exception when the message content does not contain s3 details`() {
       val message = """
         {

--- a/src/test/resources/emailExamples/email-file
+++ b/src/test/resources/emailExamples/email-file
@@ -1,5 +1,5 @@
 From: test@email.com
-Subject: Crime Mapping Request
+Subject: Bedfordshire - Crime Mapping Request - 20251015
 Date: Wed, 15 Oct 2025 13:56:58 +0000
 Accept-Language: en-GB, en-US
 Content-Language: en-GB


### PR DESCRIPTION
Additional manual testing done by running the `bash scripts/localstack-ingest-sample-email.sh` script with emails with the subjects like:

1. "Crime Mapping Request" and
2. "Bedfordshire - Crime Mapping Request - 20260722"