### PR TITLE
Police Data Ingestion Status Dashboard

### DIFF
--- a/helm_deploy/hmpps-electronic-monitoring-crime-matching-api/files/police-data-ingestion-grafana-dashboard.json
+++ b/helm_deploy/hmpps-electronic-monitoring-crime-matching-api/files/police-data-ingestion-grafana-dashboard.json
@@ -1,0 +1,375 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "limit": 100,
+        "name": "Annotations & Alerts",
+        "showIn": 0,
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": 292,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Mixed --"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "fieldMinMax": false,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 15,
+      "options": {
+        "displayMode": "gradient",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "pluginVersion": "11.5.6+security-01",
+      "targets": [
+        {
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "P896B4444D3F0DAB8"
+          },
+          "dimensions": {
+            "RuleSetName": "email-receiving-rules"
+          },
+          "expression": "",
+          "id": "",
+          "label": "Email Received",
+          "logGroups": [],
+          "matchExact": true,
+          "metricEditorMode": 0,
+          "metricName": "Received",
+          "metricQueryType": 0,
+          "namespace": "AWS/SES",
+          "period": "",
+          "queryLanguage": "CWLI",
+          "queryMode": "Metrics",
+          "refId": "A",
+          "region": "default",
+          "sqlExpression": "",
+          "statistic": "Sum"
+        },
+        {
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "P896B4444D3F0DAB8"
+          },
+          "dimensions": {
+            "QueueName": "hmpps-em-probation-devs-${environment}-email-notifications"
+          },
+          "expression": "",
+          "hide": false,
+          "id": "",
+          "label": "SQS Message Sent",
+          "logGroups": [],
+          "matchExact": true,
+          "metricEditorMode": 0,
+          "metricName": "NumberOfMessagesSent",
+          "metricQueryType": 0,
+          "namespace": "AWS/SQS",
+          "period": "",
+          "queryLanguage": "CWLI",
+          "queryMode": "Metrics",
+          "refId": "B",
+          "region": "default",
+          "sqlExpression": "",
+          "statistic": "Sum"
+        },
+        {
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "P896B4444D3F0DAB8"
+          },
+          "dimensions": {
+            "QueueName": "hmpps-em-probation-devs-${environment}-email-notifications"
+          },
+          "expression": "",
+          "hide": false,
+          "id": "",
+          "label": "SQS Message Processed",
+          "logGroups": [],
+          "matchExact": true,
+          "metricEditorMode": 0,
+          "metricName": "NumberOfMessagesDeleted",
+          "metricQueryType": 0,
+          "namespace": "AWS/SQS",
+          "period": "",
+          "queryLanguage": "CWLI",
+          "queryMode": "Metrics",
+          "refId": "D",
+          "region": "default",
+          "sqlExpression": "",
+          "statistic": "Sum"
+        }
+      ],
+      "title": "E2E Status",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "cloudwatch",
+        "uid": "P896B4444D3F0DAB8"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 16,
+      "options": {
+        "displayMode": "gradient",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "pluginVersion": "11.5.6+security-01",
+      "targets": [
+        {
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "P896B4444D3F0DAB8"
+          },
+          "dimensions": {
+            "QueueName": "hmpps-em-probation-devs-${environment}-notifications-dlq"
+          },
+          "expression": "",
+          "id": "",
+          "label": "",
+          "logGroups": [],
+          "matchExact": true,
+          "metricEditorMode": 0,
+          "metricName": "NumberOfMessagesReceived",
+          "metricQueryType": 0,
+          "namespace": "AWS/SQS",
+          "period": "",
+          "queryLanguage": "CWLI",
+          "queryMode": "Metrics",
+          "refId": "A",
+          "region": "default",
+          "sqlExpression": "",
+          "statistic": "Sum"
+        },
+        {
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "P896B4444D3F0DAB8"
+          },
+          "dimensions": {
+            "QueueName": "hmpps-em-probation-devs-${environment}-notifications-dlq"
+          },
+          "expression": "",
+          "hide": false,
+          "id": "",
+          "label": "",
+          "logGroups": [],
+          "matchExact": true,
+          "metricEditorMode": 0,
+          "metricName": "NumberOfMessagesDeleted",
+          "metricQueryType": 0,
+          "namespace": "AWS/SQS",
+          "period": "",
+          "queryLanguage": "CWLI",
+          "queryMode": "Metrics",
+          "refId": "C",
+          "region": "default",
+          "sqlExpression": "",
+          "statistic": "Sum"
+        }
+      ],
+      "title": "DLQ Status",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 17,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "11.5.6+security-01",
+      "targets": [
+        {
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "count by (ingestionStatus) (increase(email_ingestion_outcome_total{namespace=\"hmpps-electronic-monitoring-crime-matching-${environment}\"}[$__range]))",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Ingestions By Status",
+      "type": "gauge"
+    }
+  ],
+  "preload": false,
+  "refresh": "",
+  "schemaVersion": 40,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "name": "environment",
+        "label": "Environment",
+        "type": "custom",
+        "query": "dev,preprod,prod",
+        "current": {
+          "selected": true,
+          "text": "dev",
+          "value": "dev"
+        }
+      }
+    ]
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Police Data Ingestion Dashboard",
+  "uid": "afsdv98od660we",
+  "version": 1,
+  "weekStart": ""
+}

--- a/helm_deploy/hmpps-electronic-monitoring-crime-matching-api/files/police-data-ingestion-grafana-dashboard.json
+++ b/helm_deploy/hmpps-electronic-monitoring-crime-matching-api/files/police-data-ingestion-grafana-dashboard.json
@@ -86,37 +86,12 @@
             "uid": "P896B4444D3F0DAB8"
           },
           "dimensions": {
-            "RuleSetName": "email-receiving-rules"
-          },
-          "expression": "",
-          "id": "",
-          "label": "Email Received",
-          "logGroups": [],
-          "matchExact": true,
-          "metricEditorMode": 0,
-          "metricName": "Received",
-          "metricQueryType": 0,
-          "namespace": "AWS/SES",
-          "period": "",
-          "queryLanguage": "CWLI",
-          "queryMode": "Metrics",
-          "refId": "A",
-          "region": "default",
-          "sqlExpression": "",
-          "statistic": "Sum"
-        },
-        {
-          "datasource": {
-            "type": "cloudwatch",
-            "uid": "P896B4444D3F0DAB8"
-          },
-          "dimensions": {
             "QueueName": "hmpps-em-probation-devs-${environment}-email-notifications"
           },
           "expression": "",
           "hide": false,
           "id": "",
-          "label": "SQS Message Sent",
+          "label": "SQS Messages Sent",
           "logGroups": [],
           "matchExact": true,
           "metricEditorMode": 0,
@@ -142,7 +117,7 @@
           "expression": "",
           "hide": false,
           "id": "",
-          "label": "SQS Message Processed",
+          "label": "SQS Messages Processed",
           "logGroups": [],
           "matchExact": true,
           "metricEditorMode": 0,
@@ -158,7 +133,7 @@
           "statistic": "Sum"
         }
       ],
-      "title": "E2E Status",
+      "title": "SQS Status",
       "type": "bargauge"
     },
     {
@@ -227,7 +202,7 @@
             "uid": "P896B4444D3F0DAB8"
           },
           "dimensions": {
-            "QueueName": "hmpps-em-probation-devs-${environment}-notifications-dlq"
+            "QueueName": "hmpps-em-probation-devs-${environment}-email-notifications-dlq"
           },
           "expression": "",
           "id": "",
@@ -252,7 +227,7 @@
             "uid": "P896B4444D3F0DAB8"
           },
           "dimensions": {
-            "QueueName": "hmpps-em-probation-devs-${environment}-notifications-dlq"
+            "QueueName": "hmpps-em-probation-devs-${environment}-email-notifications-dlq"
           },
           "expression": "",
           "hide": false,
@@ -277,70 +252,157 @@
       "type": "bargauge"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
+      "id": 17,
+      "type": "piechart",
+      "title": "Ingestions By Status",
+      "gridPos": {
+        "x": 0,
+        "y": 8,
+        "h": 8,
+        "w": 12
       },
       "fieldConfig": {
         "defaults": {
+          "custom": {
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            }
+          },
           "color": {
-            "mode": "thresholds"
+            "mode": "palette-classic"
           },
           "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
+          "fieldMinMax": false
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "PARTIAL"
+            },
+            "properties": [
               {
-                "color": "green",
-                "value": null
-              },
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "yellow"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SUCCESSFUL"
+            },
+            "properties": [
               {
-                "color": "red",
-                "value": 80
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "green"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "FAILED"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "red"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ERROR"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "orange"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "UNKNOWN"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "transparent"
+                }
               }
             ]
           }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 8
-      },
-      "id": 17,
-      "options": {
-        "minVizHeight": 75,
-        "minVizWidth": 75,
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showThresholdLabels": false,
-        "showThresholdMarkers": true,
-        "sizing": "auto"
+        ]
       },
       "pluginVersion": "11.5.6+security-01",
       "targets": [
         {
           "disableTextWrap": false,
-          "editorMode": "code",
-          "expr": "count by (ingestionStatus) (increase(email_ingestion_outcome_total{namespace=\"hmpps-electronic-monitoring-crime-matching-${environment}\"}[$__range]))",
+          "editorMode": "builder",
+          "expr": "count by(ingestionStatus) (email_ingestion_outcome_total{namespace=\"hmpps-electronic-monitoring-crime-matching-${environment}\"})",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
-          "legendFormat": "__auto",
+          "legendFormat": "{{label_name}}",
           "range": true,
           "refId": "A",
-          "useBackend": false
+          "useBackend": false,
+          "interval": "",
+          "exemplar": false,
+          "instant": false,
+          "format": "time_series"
         }
       ],
-      "title": "Ingestions By Status",
-      "type": "gauge"
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "last"
+          ],
+          "fields": ""
+        },
+        "pieType": "pie",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none",
+          "hideZeros": false
+        },
+        "legend": {
+          "showLegend": true,
+          "displayMode": "list",
+          "placement": "bottom",
+          "values": [
+            "value"
+          ]
+        },
+        "displayLabels": [
+          "value",
+          "name"
+        ]
+      }
     }
   ],
   "preload": false,

--- a/helm_deploy/hmpps-electronic-monitoring-crime-matching-api/templates/police-data-ingestion-grafana-dashboard.yaml
+++ b/helm_deploy/hmpps-electronic-monitoring-crime-matching-api/templates/police-data-ingestion-grafana-dashboard.yaml
@@ -1,0 +1,11 @@
+{{ if .Values.deploy_grafana_dashboards }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: police-data-ingestion-grafana-dashboard
+  labels:
+    grafana_dashboard: "police-data-ingestion-grafana-dashboard"
+data:
+  police-data-ingestion-dashboard.json: |
+    {{ .Files.Get "files/police-data-ingestion-dashboard.json" | nindent 4 }}
+{{ end }}

--- a/helm_deploy/hmpps-electronic-monitoring-crime-matching-api/values.yaml
+++ b/helm_deploy/hmpps-electronic-monitoring-crime-matching-api/values.yaml
@@ -90,3 +90,6 @@ generic-prometheus-alerts:
 # Override in values-dev.yaml
 # Also update the environment variables to point the application to the mocked services (on port 80)
 deploy_stubs: false
+
+# Grafana dashboards only need to be deployed once and are shared across environments
+deploy_grafana_dashboards: false

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -31,3 +31,4 @@ generic-prometheus-alerts:
   rdsAlertsConnectionThreshold: 65
 
 deploy_stubs: false
+deploy_grafana_dashboards: true


### PR DESCRIPTION
### Changes
Adding a simple grafana dashboard for the police data ingestion to consolidate key status indicators of the pipeline. 
The dashboard outputs:
- SQS Messages Sent
- SQS Messages Processed
- DLQ Messages Received
- DLQ Messages Deleted
- Processed Ingestions By Status
<img width="1612" height="751" alt="image" src="https://github.com/user-attachments/assets/eeb9351f-31c0-47ee-b322-cf0d6c73b2d0" />



