### PR TITLE
Add deviceSerialNumber to create crime matching run endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/dto/CrimeMatchingResultDeviceWearerRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/dto/CrimeMatchingResultDeviceWearerRequest.kt
@@ -15,6 +15,9 @@ data class CrimeMatchingResultDeviceWearerRequest(
   @field:NotNull(message = "deviceId is required")
   val deviceId: Long,
 
+  @field:NotNull(message = "deviceSerialNumber is required")
+  val deviceSerialNumber: Long,
+
   @field:NotBlank(message = "deviceName is required")
   val deviceName: String,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/model/entity/CrimeMatchingResultDeviceWearer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/model/entity/CrimeMatchingResultDeviceWearer.kt
@@ -37,6 +37,8 @@ data class CrimeMatchingResultDeviceWearer(
 
   val deviceId: Long,
 
+  val deviceSerialNumber: Long,
+
   @Column(nullable = false)
   val deviceName: String,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/crimeMatching/CrimeMatchingRunService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/crimeMatching/CrimeMatchingRunService.kt
@@ -86,6 +86,7 @@ class CrimeMatchingRunService(
       address = wearerDto.address,
       dateOfBirth = wearerDto.dateOfBirth,
       deviceId = wearerDto.deviceId,
+      deviceSerialNumber = wearerDto.deviceSerialNumber,
       deviceName = wearerDto.deviceName,
       identifier = wearerDto.identifier,
       name = wearerDto.name,

--- a/src/main/resources/db/migration/V3__crime_matching_tables.sql
+++ b/src/main/resources/db/migration/V3__crime_matching_tables.sql
@@ -14,6 +14,7 @@ CREATE TABLE crime_matching_result_device_wearer
     address                  VARCHAR(255) NOT NULL,
     date_of_birth            TIMESTAMP WITHOUT TIME ZONE NOT NULL,
     device_id                BIGINT NOT NULL,
+    device_serial_number     BIGINT NOT NULL,
     device_name              VARCHAR(255) NOT NULL,
     identifier               VARCHAR(255) NOT NULL,
     name                     VARCHAR(255) NOT NULL,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/fixtures/CrimeMatchingRunContext.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/fixtures/CrimeMatchingRunContext.kt
@@ -10,6 +10,7 @@ class CrimeMatchingRunContext(
   fun withMatchedDeviceWearer(
     address: String = "address",
     deviceId: Long,
+    deviceSerialNumber: Long = 123456789,
     deviceName: String = "deviceName",
     dateOfBirth: LocalDateTime = LocalDateTime.of(2025, 1, 1, 1, 1),
     identifier: String = "1",
@@ -23,6 +24,7 @@ class CrimeMatchingRunContext(
       address = address,
       dateOfBirth = dateOfBirth,
       deviceId = deviceId,
+      deviceSerialNumber = deviceSerialNumber,
       deviceName = deviceName,
       identifier = identifier,
       name = name,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/resource/CrimeMatchingRunControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/resource/CrimeMatchingRunControllerTest.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.integration.resource
 
-
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -10,6 +9,8 @@ import org.springframework.http.MediaType
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.reactive.server.expectBody
 import org.springframework.transaction.support.TransactionTemplate
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.dto.CreateCrimeMatchingRunResponse
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.dto.Response
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.entity.Crime
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.entity.CrimeBatch
@@ -24,8 +25,6 @@ import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.reposit
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.repository.crimeBatch.CrimeRepository
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.repository.crimeBatch.CrimeVersionRepository
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.repository.crimeMatching.CrimeMatchingRunRepository
-import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.dto.CreateCrimeMatchingRunResponse
-import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.dto.Response
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneOffset
@@ -115,17 +114,6 @@ class CrimeMatchingRunControllerTest : IntegrationTestBase() {
     @Test
     fun `it should create a crime matching run and return 201 with run id`() {
       val (crimeBatchId, _) = createCrimeBatchWithCrimeVersion()
-
-//      webTestClient.post()
-//        .uri("/crime-matching-run")
-//        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__CRIME_MATCHING_RESULTS__RW")))
-//        .contentType(MediaType.APPLICATION_JSON)
-//        .bodyValue("create-crime-matching-run-request".loadJson())
-//        .exchange()
-//        .expectStatus().isCreated
-//        .expectBody()
-//        .jsonPath("$.data.id").exists()
-//        .jsonPath("$.data.id").isNotEmpty
 
       val response = webTestClient.post()
         .uri("/crime-matching-run")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/resource/CrimeMatchingRunControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/resource/CrimeMatchingRunControllerTest.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.integration.resource
 
+
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -7,6 +8,8 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
 import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.reactive.server.expectBody
+import org.springframework.transaction.support.TransactionTemplate
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.entity.Crime
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.entity.CrimeBatch
@@ -21,6 +24,8 @@ import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.reposit
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.repository.crimeBatch.CrimeRepository
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.repository.crimeBatch.CrimeVersionRepository
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.repository.crimeMatching.CrimeMatchingRunRepository
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.dto.CreateCrimeMatchingRunResponse
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.dto.Response
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneOffset
@@ -32,6 +37,9 @@ class CrimeMatchingRunControllerTest : IntegrationTestBase() {
 
   @Autowired
   lateinit var crimeMatchingRunRepository: CrimeMatchingRunRepository
+
+  @Autowired
+  lateinit var transactionTemplate: TransactionTemplate
 
   @Autowired
   lateinit var crimeBatchRepository: CrimeBatchRepository
@@ -108,24 +116,50 @@ class CrimeMatchingRunControllerTest : IntegrationTestBase() {
     fun `it should create a crime matching run and return 201 with run id`() {
       val (crimeBatchId, _) = createCrimeBatchWithCrimeVersion()
 
-      webTestClient.post()
+//      webTestClient.post()
+//        .uri("/crime-matching-run")
+//        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__CRIME_MATCHING_RESULTS__RW")))
+//        .contentType(MediaType.APPLICATION_JSON)
+//        .bodyValue("create-crime-matching-run-request".loadJson())
+//        .exchange()
+//        .expectStatus().isCreated
+//        .expectBody()
+//        .jsonPath("$.data.id").exists()
+//        .jsonPath("$.data.id").isNotEmpty
+
+      val response = webTestClient.post()
         .uri("/crime-matching-run")
         .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__CRIME_MATCHING_RESULTS__RW")))
         .contentType(MediaType.APPLICATION_JSON)
         .bodyValue("create-crime-matching-run-request".loadJson())
         .exchange()
         .expectStatus().isCreated
-        .expectBody()
-        .jsonPath("$.data.id").exists()
-        .jsonPath("$.data.id").isNotEmpty
+        .expectBody<Response<CreateCrimeMatchingRunResponse>>()
+        .returnResult().responseBody!!
 
       assertThat(crimeMatchingRunRepository.count()).isEqualTo(1)
 
-      val run = crimeMatchingRunRepository.findAll().first()
-      assertThat(run.algorithmVersion).isEqualTo("e83c5163316f89bfbde7d9ab23ca2e25604af290")
-      assertThat(run.crimeBatch.id).isEqualTo(crimeBatchId)
-      assertThat(run.triggerType.name).isEqualTo("AUTO")
-      assertThat(run.status.name).isEqualTo("SUCCESS")
+      transactionTemplate.executeWithoutResult {
+        val run = crimeMatchingRunRepository
+          .findById(UUID.fromString(response.data.id))
+          .orElseThrow()
+
+        assertThat(run.algorithmVersion).isEqualTo("e83c5163316f89bfbde7d9ab23ca2e25604af290")
+        assertThat(run.crimeBatch.id).isEqualTo(crimeBatchId)
+        assertThat(run.triggerType.name).isEqualTo("AUTO")
+        assertThat(run.status.name).isEqualTo("SUCCESS")
+        assertThat(run.results.size).isEqualTo(1)
+        assertThat(run.results[0].deviceWearers).hasSize(1)
+        assertThat(run.results[0].deviceWearers[0].address).isEqualTo("address")
+        assertThat(run.results[0].deviceWearers[0].dateOfBirth).isEqualTo(LocalDateTime.of(1980, 1, 1, 0, 0))
+        assertThat(run.results[0].deviceWearers[0].name).isEqualTo("Richard Gibbons")
+        assertThat(run.results[0].deviceWearers[0].identifier).isEqualTo("identifier")
+        assertThat(run.results[0].deviceWearers[0].nomisId).isEqualTo("A5128CZ")
+        assertThat(run.results[0].deviceWearers[0].pncRef).isEqualTo("pncRef")
+        assertThat(run.results[0].deviceWearers[0].deviceId).isEqualTo(604008982)
+        assertThat(run.results[0].deviceWearers[0].deviceSerialNumber).isEqualTo(123456789)
+        assertThat(run.results[0].deviceWearers[0].deviceName).isEqualTo("deviceName")
+      }
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/crimeMatching/CrimeMatchingRunServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/crimeMatching/CrimeMatchingRunServiceTest.kt
@@ -172,6 +172,7 @@ class CrimeMatchingRunServiceTest {
                 address = "address",
                 dateOfBirth = LocalDateTime.of(1980, 1, 1, 1, 1, 1),
                 deviceId = 604008982,
+                deviceSerialNumber = 123456789,
                 deviceName = "deviceName",
                 identifier = "identifier",
                 name = "Richard Gibbons",

--- a/src/test/resources/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/resource/create-crime-matching-run-request.json
+++ b/src/test/resources/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/resource/create-crime-matching-run-request.json
@@ -13,6 +13,7 @@
           "address": "address",
           "dateOfBirth": "1980-01-01T00:00:00",
           "deviceId": 604008982,
+          "deviceSerialNumber": 123456789,
           "deviceName": "deviceName",
           "name": "Richard Gibbons",
           "identifier": "identifier",


### PR DESCRIPTION
We need to display the `deviceSerialNumber` in the user interface. To do that we must first collect the serial number as part of a crime matching result.