### PR TITLE
Initialise metrics at application startup

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/internal/MetricsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/internal/MetricsService.kt
@@ -2,22 +2,41 @@ package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.servic
 
 import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.MeterRegistry
+import jakarta.annotation.PostConstruct
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.EmailIngestionOutcome
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.enums.IngestionStatus
 
 @Service
-class MetricsService(private val meterRegistry: MeterRegistry) {
+class MetricsService(
+  private val meterRegistry: MeterRegistry,
+) {
+  private val counters =
+    mutableMapOf<IngestionStatus, Counter>()
 
   companion object {
     private const val MESSAGE_OUTCOME = "email.ingestion.outcome"
   }
 
+  @PostConstruct
+  fun initialise() {
+    IngestionStatus.entries.forEach { status ->
+      counters[status] = createEmailIngestionOutcomeCounter(
+        ingestionStatus = status,
+      )
+    }
+  }
+
+  private fun createEmailIngestionOutcomeCounter(
+    ingestionStatus: IngestionStatus,
+  ): Counter = Counter.builder(MESSAGE_OUTCOME)
+    .description("Email ingestion outcomes by police force and status")
+    .tag("ingestionStatus", ingestionStatus.name)
+    .register(meterRegistry)
+
   fun recordOutcome(outcome: EmailIngestionOutcome) {
-    Counter.builder(MESSAGE_OUTCOME)
-      .description("Email ingestion outcomes by police force and status")
-      .tag("policeForce", outcome.policeForce)
-      .tag("ingestionStatus", outcome.ingestionStatus.name)
-      .register(meterRegistry)
+    counters
+      .getValue(outcome.ingestionStatus)
       .increment()
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/internal/MetricsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/internal/MetricsService.kt
@@ -30,7 +30,7 @@ class MetricsService(
   private fun createEmailIngestionOutcomeCounter(
     ingestionStatus: IngestionStatus,
   ): Counter = Counter.builder(MESSAGE_OUTCOME)
-    .description("Email ingestion outcomes by police force and status")
+    .description("Email ingestion outcomes by status")
     .tag("ingestionStatus", ingestionStatus.name)
     .register(meterRegistry)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/listener/EmailListenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/listener/EmailListenerTest.kt
@@ -124,7 +124,6 @@ class EmailListenerTest : IntegrationTestBase() {
     crimeBatchRepository.deleteAll()
     crimeRepository.deleteAll()
     crimeBatchIngestionAttemptRepository.deleteAll()
-    meterRegistry.clear()
   }
 
   @AfterEach
@@ -144,6 +143,12 @@ class EmailListenerTest : IntegrationTestBase() {
   inner class ReceiveEmailNotification {
     @Test
     fun `it should process a valid email notification`() {
+      val outcomeMetric = meterRegistry.get("email.ingestion.outcome").tags(
+        "ingestionStatus",
+        IngestionStatus.SUCCESSFUL.name,
+      ).counter()
+      val countBefore = outcomeMetric.count()
+
       val csvContent = listOf(
         createCsvRow(),
         createCsvRow(crimeReference = "CRI00000002"),
@@ -178,19 +183,18 @@ class EmailListenerTest : IntegrationTestBase() {
       // Check that notification to start algo was generated
       assertThat(getNumberOfMessagesCurrentlyOnMatchingNotificationsQueue()).isEqualTo(1)
 
-      // Check outcome metric recorded with expected count and tags
-      val outcomeMetric = meterRegistry.get("email.ingestion.outcome").tags(
-        "policeForce",
-        "Metropolitan",
-        "ingestionStatus",
-        IngestionStatus.SUCCESSFUL.name,
-      ).counter().count()
-
-      assertThat(outcomeMetric).isEqualTo(1.0)
+      // Check outcome metric was incremented
+      assertThat(outcomeMetric.count()).isEqualTo(countBefore + 1)
     }
 
     @Test
     fun `it should save an ingestion attempt with an error when the email is missing an attachment`() {
+      val outcomeMetric = meterRegistry.get("email.ingestion.outcome").tags(
+        "ingestionStatus",
+        IngestionStatus.FAILED.name,
+      ).counter()
+      val countBefore = outcomeMetric.count()
+
       val email = createEmailFileWithoutAttachment()
 
       s3Client.putObject(PutObjectRequest.builder().bucket(BUCKET_NAME).key(OBJECT_KEY).build(), RequestBody.fromString(email))
@@ -210,19 +214,17 @@ class EmailListenerTest : IntegrationTestBase() {
       // Check that notification to start algo was not generated
       assertThat(getNumberOfMessagesCurrentlyOnMatchingNotificationsQueue()).isEqualTo(0)
 
-      // Check outcome metric recorded with expected count and tags
-      val outcomeMetric = meterRegistry.get("email.ingestion.outcome").tags(
-        "policeForce",
-        "Unknown due to an error",
-        "ingestionStatus",
-        IngestionStatus.FAILED.name,
-      ).counter().count()
-
-      assertThat(outcomeMetric).isEqualTo(1.0)
+      // Check outcome metric was incremented
+      assertThat(outcomeMetric.count()).isEqualTo(countBefore + 1)
     }
 
     @Test
     fun `it should save an ingestion attempt with an error when the email has multiple attachments`() {
+      val outcomeMetric = meterRegistry.get("email.ingestion.outcome").tags(
+        "ingestionStatus",
+        IngestionStatus.FAILED.name,
+      ).counter()
+      val countBefore = outcomeMetric.count()
       val email = createEmailFileWithMultipleAttachments()
 
       s3Client.putObject(PutObjectRequest.builder().bucket(BUCKET_NAME).key(OBJECT_KEY).build(), RequestBody.fromString(email))
@@ -243,19 +245,19 @@ class EmailListenerTest : IntegrationTestBase() {
       // Check that notification to start algo was not generated
       assertThat(getNumberOfMessagesCurrentlyOnMatchingNotificationsQueue()).isEqualTo(0)
 
-      // Check outcome metric recorded with expected count and tags
-      val outcomeMetric = meterRegistry.get("email.ingestion.outcome").tags(
-        "policeForce",
-        "Unknown due to an error",
-        "ingestionStatus",
-        IngestionStatus.FAILED.name,
-      ).counter().count()
-
-      assertThat(outcomeMetric).isEqualTo(1.0)
+      // Check outcome metric was incremented
+      assertThat(outcomeMetric.count()).isEqualTo(countBefore + 1)
     }
 
     @Test
     fun `it should save an ingestion attempt with an error when the csv has multiple police forces`() {
+      // Check outcome metric recorded with expected count and tags
+      val outcomeMetric = meterRegistry.get("email.ingestion.outcome").tags(
+        "ingestionStatus",
+        IngestionStatus.FAILED.name,
+      ).counter()
+      val countBefore = outcomeMetric.count()
+
       val csvContent = listOf(
         createCsvRow(),
         createCsvRow(policeForce = PoliceForce.BEDFORDSHIRE.identifier, batchId = "BFD20250126"),
@@ -278,19 +280,18 @@ class EmailListenerTest : IntegrationTestBase() {
       // Check that notification to start algo was not generated
       assertThat(getNumberOfMessagesCurrentlyOnMatchingNotificationsQueue()).isEqualTo(0)
 
-      // Check outcome metric recorded with expected count and tags
-      val outcomeMetric = meterRegistry.get("email.ingestion.outcome").tags(
-        "policeForce",
-        "Unknown due to an error",
-        "ingestionStatus",
-        IngestionStatus.FAILED.name,
-      ).counter().count()
-
-      assertThat(outcomeMetric).isEqualTo(1.0)
+      // Check outcome metric was incremented
+      assertThat(outcomeMetric.count()).isEqualTo(countBefore + 1)
     }
 
     @Test
     fun `it should save an ingestion attempt with an error when the csv has multiple batch IDs`() {
+      val outcomeMetric = meterRegistry.get("email.ingestion.outcome").tags(
+        "ingestionStatus",
+        IngestionStatus.FAILED.name,
+      ).counter()
+      val countBefore = outcomeMetric.count()
+
       val csvContent = listOf(
         createCsvRow(),
         createCsvRow(batchId = "MPS20260123"),
@@ -315,15 +316,8 @@ class EmailListenerTest : IntegrationTestBase() {
       // Check that notification to start algo was not generated
       assertThat(getNumberOfMessagesCurrentlyOnMatchingNotificationsQueue()).isEqualTo(0)
 
-      // Check outcome metric recorded with expected count and tags
-      val outcomeMetric = meterRegistry.get("email.ingestion.outcome").tags(
-        "policeForce",
-        "Unknown due to an error",
-        "ingestionStatus",
-        IngestionStatus.FAILED.name,
-      ).counter().count()
-
-      assertThat(outcomeMetric).isEqualTo(1.0)
+      // Check outcome metric was incremented
+      assertThat(outcomeMetric.count()).isEqualTo(countBefore + 1)
     }
 
     @Test
@@ -398,8 +392,6 @@ class EmailListenerTest : IntegrationTestBase() {
 
       // Check outcome metric recorded with expected count and tags
       val outcomeMetric = meterRegistry.get("email.ingestion.outcome").tags(
-        "policeForce",
-        "Metropolitan",
         "ingestionStatus",
         IngestionStatus.PARTIAL.name,
       ).counter().count()
@@ -435,8 +427,6 @@ class EmailListenerTest : IntegrationTestBase() {
 
       // Check outcome metric recorded with expected count and tags
       val outcomeMetric = meterRegistry.get("email.ingestion.outcome").tags(
-        "policeForce",
-        "Unknown due to an error",
         "ingestionStatus",
         IngestionStatus.ERROR.name,
       ).counter().count()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/listener/EmailListenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/listener/EmailListenerTest.kt
@@ -359,6 +359,12 @@ class EmailListenerTest : IntegrationTestBase() {
 
     @Test
     fun `it should process an email with valid and invalid crime data`() {
+      val outcomeMetric = meterRegistry.get("email.ingestion.outcome").tags(
+        "ingestionStatus",
+        IngestionStatus.PARTIAL.name,
+      ).counter()
+      val countBefore = outcomeMetric.count()
+
       val csvContent = listOf(
         createCsvRow(),
         createCsvRow(crimeTypeId = "invalid"),
@@ -390,17 +396,18 @@ class EmailListenerTest : IntegrationTestBase() {
       // Check that notification to start algo was generated
       assertThat(getNumberOfMessagesCurrentlyOnMatchingNotificationsQueue()).isEqualTo(1)
 
-      // Check outcome metric recorded with expected count and tags
-      val outcomeMetric = meterRegistry.get("email.ingestion.outcome").tags(
-        "ingestionStatus",
-        IngestionStatus.PARTIAL.name,
-      ).counter().count()
-
-      assertThat(outcomeMetric).isEqualTo(1.0)
+      // Check outcome metric was incremented
+      assertThat(outcomeMetric.count()).isEqualTo(countBefore + 1)
     }
 
     @Test
     fun `it should process an email with only invalid crime data`() {
+      val outcomeMetric = meterRegistry.get("email.ingestion.outcome").tags(
+        "ingestionStatus",
+        IngestionStatus.ERROR.name,
+      ).counter()
+      val countBefore = outcomeMetric.count()
+
       val csvContent = listOf(
         createCsvRow(latitude = "invalid"),
         createCsvRow(crimeTypeId = "invalid"),
@@ -425,13 +432,8 @@ class EmailListenerTest : IntegrationTestBase() {
       // Check that notification to start algo was generated
       assertThat(getNumberOfMessagesCurrentlyOnMatchingNotificationsQueue()).isEqualTo(0)
 
-      // Check outcome metric recorded with expected count and tags
-      val outcomeMetric = meterRegistry.get("email.ingestion.outcome").tags(
-        "ingestionStatus",
-        IngestionStatus.ERROR.name,
-      ).counter().count()
-
-      assertThat(outcomeMetric).isEqualTo(1.0)
+      // Check outcome metric was incremented
+      assertThat(outcomeMetric.count()).isEqualTo(countBefore + 1)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/internal/MetricsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/internal/MetricsServiceTest.kt
@@ -19,6 +19,7 @@ class MetricsServiceTest {
   fun setup() {
     meterRegistry = SimpleMeterRegistry()
     service = MetricsService(meterRegistry)
+    service.initialise()
   }
 
   @Test
@@ -42,8 +43,6 @@ class MetricsServiceTest {
     service.recordOutcome(ingestionOutcome)
 
     val outcomeMetric = meterRegistry.get("email.ingestion.outcome").tags(
-      "policeForce",
-      "Bedfordshire",
       "ingestionStatus",
       IngestionStatus.SUCCESSFUL.name,
     ).counter().count()


### PR DESCRIPTION
## Summary

Initialise email-ingestion outcome counters when the application starts and reuse the registered counters when recording outcomes.

The `policeForce` dimension has also been removed from the metric, and the integration tests now assert changes in counter values rather than clearing the meter registry between tests.

## Why initialise counters at startup?

Micrometer does not expose a counter time series until that counter has been registered.

Previously, a counter was first registered when an email outcome occurred. This meant that Prometheus first observed the metric with a value of `1`, with no earlier `0` sample for that ingestion status.

Registering a counter for each ingestion status at application startup allows Prometheus to scrape the series while its value is still `0`. When an email is subsequently processed, the metric can be observed increasing from `0` to `1`.

This makes range queries such as `increase()` more reliable, particularly when the first email is processed shortly after the application starts and allows us to create dashboards like this which show use the number of emails for each ingestionStatus in the time range (the top row of stats) as well as the trend of ingestionStatus (the right hand time series).

<img width="2230" height="612" alt="Screenshot 2026-08-04 at 13 32 30" src="https://github.com/user-attachments/assets/743c0149-d2ac-4ec4-82bf-77819bffc2a1" />


## Removing the police-force dimension

The `policeForce` tag has been removed from the email-ingestion outcome metric.

Including both police force and ingestion status created a separate Prometheus time series for every combination. With the 19 police forces currently in scope and 5 ingestion statuses, this would produce:

```text
19 × 5 = 95 time series
```

Most of these series would usually remain at zero, with a single increment each day (i.e. generally one email per police force per day with some exceptions). If we need this information, we can query the db.

This would become more significant if the service is expanded to all 43 police forces:

```text
43 × 5 = 215 time series
```

The metric is intended to show the overall number of email-ingestion outcomes by status, so the police-force dimension is not required for the current dashboards and alerts.

## Integration-test changes

The integration tests previously cleared the meter registry after every test.

Micrometer counters are monotonic: they can increase but cannot be reset to zero. Clearing the registry removes the registered meters, but `MetricsService` continues to hold references to the original counter instances created at application startup. Those counters are no longer visible through the registry after it has been cleared.

Spring also reuses the application context between integration tests, so `@PostConstruct` is not rerun after each test to recreate the removed counters.

The tests now leave the registry intact and:

1. Record the counter value before performing the action.
2. Perform the email-ingestion operation.
3. Assert that the counter increased by the expected amount.

This verifies that the individual test caused the increment without relying on the counter having an absolute value of zero at the beginning of the test.
