### PR TITLE
Publish Matching Request notification after saving crime batch

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/model/EmailIngestionOutcome.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/model/EmailIngestionOutcome.kt
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.v
 
 data class EmailIngestionOutcome(
   val batchId: String = "Unknown due to an error",
+  val crimeBatchId: String = "Unknown due to an error",
   val policeForce: String = "Unknown due to an error",
   val errorType: CrimeBatchEmailIngestionErrorType = CrimeBatchEmailIngestionErrorType.UNKNOWN,
   val errors: List<EmailAttachmentIngestionError> = emptyList(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/crimeBatch/CrimeBatchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/crimeBatch/CrimeBatchService.kt
@@ -19,7 +19,6 @@ import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.reposit
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.repository.crimeBatch.CrimeRepository
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.repository.crimeBatch.CrimeVersionRepository
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.repository.projection.CrimeBatchIngestionAttemptSummaryProjection
-import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.service.MatchingNotificationService
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -28,7 +27,6 @@ class CrimeBatchService(
   private val crimeBatchRepository: CrimeBatchRepository,
   private val crimeRepository: CrimeRepository,
   private val crimeVersionRepository: CrimeVersionRepository,
-  private val matchingNotificationService: MatchingNotificationService,
   private val crimeBatchIngestionAttemptRepository: CrimeBatchIngestionAttemptRepository,
 ) {
 
@@ -63,8 +61,6 @@ class CrimeBatchService(
 
     // Save batch
     crimeBatchRepository.save(crimeBatch)
-
-    matchingNotificationService.publishMatchingRequest(crimeBatch.id.toString())
 
     return crimeBatch
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/internal/EmailListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/internal/EmailListener.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.e
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.entity.CrimeBatchIngestionAttempt
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.enums.CrimeBatchEmailIngestionErrorType
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.enums.IngestionStatus
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.service.MatchingNotificationService
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.service.crimeBatch.CrimeBatchCsvService
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.service.crimeBatch.CrimeBatchEmailIngestionService
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.service.crimeBatch.CrimeBatchService
@@ -28,6 +29,7 @@ class EmailListener(
   private val crimeBatchService: CrimeBatchService,
   private val emailNotificationService: EmailNotificationService,
   private val emailParserService: EmailParserService,
+  private val matchingNotificationService: MatchingNotificationService,
   private val metricsService: MetricsService,
 ) {
 
@@ -54,6 +56,10 @@ class EmailListener(
 
     // Record ingestion outcome
     metricsService.recordOutcome(ingestionOutcome)
+
+    if (ingestionOutcome.ingestionStatus == IngestionStatus.SUCCESSFUL || ingestionOutcome.ingestionStatus == IngestionStatus.PARTIAL) {
+      matchingNotificationService.publishMatchingRequest(ingestionOutcome.crimeBatchId)
+    }
 
     try {
       emailNotificationService.sendEmails(ingestionOutcome)
@@ -116,9 +122,11 @@ class EmailListener(
       val crimeBatch = crimeBatchService.createCrimeBatch(parseResult.records, crimeBatchEmailAttachment)
       val policeForce = parseResult.records.first().policeForce
       val batchId = crimeBatch.batchId
+      val crimeBatchId = crimeBatch.id.toString()
       val status = if (parseResult.errors.isEmpty()) IngestionStatus.SUCCESSFUL else IngestionStatus.PARTIAL
       return EmailIngestionOutcome(
         batchId = batchId,
+        crimeBatchId = crimeBatchId,
         policeForce = policeForce.label,
         errors = parseResult.errors,
         emailData = emailData,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/crimeBatch/CrimeBatchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/crimeBatch/CrimeBatchServiceTest.kt
@@ -22,7 +22,6 @@ import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.reposit
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.repository.crimeBatch.CrimeBatchRepository
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.repository.crimeBatch.CrimeRepository
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.repository.crimeBatch.CrimeVersionRepository
-import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.service.MatchingNotificationService
 import java.time.LocalDateTime
 import java.time.ZoneOffset
 
@@ -33,20 +32,17 @@ class CrimeBatchServiceTest {
   private lateinit var crimeRepository: CrimeRepository
   private lateinit var crimeVersionRepository: CrimeVersionRepository
   private lateinit var service: CrimeBatchService
-  private lateinit var matchingNotificationService: MatchingNotificationService
 
   @BeforeEach
   fun setup() {
     crimeBatchRepository = Mockito.mock(CrimeBatchRepository::class.java)
     crimeRepository = Mockito.mock(CrimeRepository::class.java)
-    matchingNotificationService = Mockito.mock(MatchingNotificationService::class.java)
     crimeVersionRepository = Mockito.mock(CrimeVersionRepository::class.java)
     crimeBatchIngestionAttemptRepository = Mockito.mock(CrimeBatchIngestionAttemptRepository::class.java)
     service = CrimeBatchService(
       crimeBatchRepository,
       crimeRepository,
       crimeVersionRepository,
-      matchingNotificationService,
       crimeBatchIngestionAttemptRepository,
     )
   }
@@ -85,17 +81,14 @@ class CrimeBatchServiceTest {
       )
       val crimeCaptor = argumentCaptor<Crime>()
       val crimeBatchCaptor = argumentCaptor<CrimeBatch>()
-      val notificationCaptor = argumentCaptor<String>()
 
       verify(crimeRepository, times(1)).save(crimeCaptor.capture())
       verify(crimeBatchRepository, times(1)).save(crimeBatchCaptor.capture())
-      verify(matchingNotificationService, times(1)).publishMatchingRequest(notificationCaptor.capture())
 
       assertThat(crimeBatchCaptor.allValues.first().crimeBatchEmailAttachment).isEqualTo(crimeBatchEmailAttachment)
       assertThat(crimeBatchCaptor.allValues.first().batchId).isEqualTo("batchId")
       assertThat(crimeBatchCaptor.allValues.first().crimeVersions).isNotEmpty()
       assertThat(crimeBatchCaptor.allValues.first().crimeVersions).hasSize(1)
-      assertThat(notificationCaptor.allValues.first()).isEqualTo(crimeBatchCaptor.allValues.first().id.toString())
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/internal/EmailListenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/internal/EmailListenerTest.kt
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.mockito.Mockito
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -28,6 +29,7 @@ import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.e
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.entity.CrimeBatchEmail
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.entity.CrimeBatchEmailAttachment
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.entity.CrimeBatchIngestionAttempt
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.service.MatchingNotificationService
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.service.crimeBatch.CrimeBatchCsvService
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.service.crimeBatch.CrimeBatchEmailIngestionService
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.service.crimeBatch.CrimeBatchService
@@ -45,6 +47,7 @@ class EmailListenerTest {
   private lateinit var crimeBatchService: CrimeBatchService
   private lateinit var emailNotificationService: EmailNotificationService
   private lateinit var emailParserService: EmailParserService
+  private lateinit var matchingNotificationService: MatchingNotificationService
   private lateinit var metricsService: MetricsService
 
   private val mapper: ObjectMapper = jacksonObjectMapper()
@@ -63,8 +66,9 @@ class EmailListenerTest {
     crimeBatchService = Mockito.mock(CrimeBatchService::class.java)
     emailNotificationService = Mockito.mock(EmailNotificationService::class.java)
     emailParserService = EmailParserService(emailIngestionProperties)
+    matchingNotificationService = Mockito.mock(MatchingNotificationService::class.java)
     metricsService = Mockito.mock(MetricsService::class.java)
-    listener = EmailListener(mapper, s3Service, crimeBatchCsvService, crimeBatchEmailIngestionService, crimeBatchService, emailNotificationService, emailParserService, metricsService)
+    listener = EmailListener(mapper, s3Service, crimeBatchCsvService, crimeBatchEmailIngestionService, crimeBatchService, emailNotificationService, emailParserService, matchingNotificationService, metricsService)
   }
 
   @Nested
@@ -143,8 +147,13 @@ class EmailListenerTest {
       )
 
       assertDoesNotThrow { listener.receiveEmailNotification(sqsMessage) }
+
+      val notificationCaptor = argumentCaptor<String>()
+      verify(matchingNotificationService, times(1)).publishMatchingRequest(notificationCaptor.capture())
       verify(emailNotificationService, times(1)).sendEmails(any())
       verify(metricsService, times(1)).recordOutcome(any())
+
+      assertThat(notificationCaptor.allValues.first()).isEqualTo(crimeBatch.id.toString())
     }
 
     @Test
@@ -220,8 +229,13 @@ class EmailListenerTest {
       )
 
       assertDoesNotThrow { listener.receiveEmailNotification(sqsMessage) }
+
+      val notificationCaptor = argumentCaptor<String>()
+      verify(matchingNotificationService, times(1)).publishMatchingRequest(notificationCaptor.capture())
       verify(emailNotificationService, times(1)).sendEmails(any())
       verify(metricsService, times(1)).recordOutcome(any())
+
+      assertThat(notificationCaptor.allValues.first()).isEqualTo(crimeBatch.id.toString())
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/internal/EmailListenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/internal/EmailListenerTest.kt
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.assertThrows
 import org.mockito.Mockito
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -149,9 +150,18 @@ class EmailListenerTest {
       assertDoesNotThrow { listener.receiveEmailNotification(sqsMessage) }
 
       val notificationCaptor = argumentCaptor<String>()
-      verify(matchingNotificationService, times(1)).publishMatchingRequest(notificationCaptor.capture())
-      verify(emailNotificationService, times(1)).sendEmails(any())
-      verify(metricsService, times(1)).recordOutcome(any())
+
+      val inOrder = inOrder(
+        crimeBatchService,
+        matchingNotificationService,
+        emailNotificationService,
+        metricsService,
+      )
+
+      inOrder.verify(crimeBatchService, times(1)).createCrimeBatch(any(), any())
+      inOrder.verify(metricsService, times(1)).recordOutcome(any())
+      inOrder.verify(matchingNotificationService, times(1)).publishMatchingRequest(notificationCaptor.capture())
+      inOrder.verify(emailNotificationService, times(1)).sendEmails(any())
 
       assertThat(notificationCaptor.allValues.first()).isEqualTo(crimeBatch.id.toString())
     }


### PR DESCRIPTION
Currently the `publishMatchingRequest` is used within the transactional function that creates and saves a crime batch, due to this the Matching Request message is at risk of being published when the crime batch itself is unavailable.

### Changes
- Moved the function to the EmailListener after an `EmailIngestionOutcome` has been produced, following a similar pattern to the `sendEmails` function.
- Added `crimeBatchId` to the `EmailIngestionOutcome` object so it can be used in the matching request message.