### PR TITLE
Disable confirmation emails to PFAs in production

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,3 +182,15 @@ bash scripts/localstack-ingest-sample-email.sh
 
 ### Code coverage
 This project has Jacoco integrated and this will run after each test run. The generated report can be found [here](build/reports/jacoco/test/html/index.html) and can be opened in your browser.
+
+### Feature flags
+Feature flags are evaluated with the [HMPPS Flipt Instance](https://github.com/ministryofjustice/hmpps-feature-flags) in the
+`hmpps-electronic-monitoring-crime-matching` namespace. The service currently only evaluates Boolean flags and will return false by default
+if a flag cannot be retrieved.
+
+Current flags:
+- `enable-police-email-notifications` - controls whether ingestion outcome notification emails are sent to the police.
+  - Default: false
+  - Prod: false
+  - Preprod: true
+  - Dev: true

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
   implementation("uk.gov.service.notify:notifications-java-client:6.1.0-RELEASE")
   implementation("org.locationtech.proj4j:proj4j:1.4.3")
   implementation("org.locationtech.proj4j:proj4j-epsg:1.4.3")
+  implementation("io.flipt:flipt-client-java:1.3.3")
 
   runtimeOnly("org.postgresql:postgresql")
   runtimeOnly("org.flywaydb:flyway-database-postgresql")

--- a/helm_deploy/hmpps-electronic-monitoring-crime-matching-api/values.yaml
+++ b/helm_deploy/hmpps-electronic-monitoring-crime-matching-api/values.yaml
@@ -19,6 +19,7 @@ generic-service:
     JAVA_OPTS: "-Xmx512m"
     SERVER_PORT: "8080"
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json
+    FLIPT_NAMESPACE: hmpps-electronic-monitoring-crime-matching
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -19,7 +19,6 @@ generic-service:
     SPRINGDOC_API-DOCS_ENABLED: "true"
     SPRINGDOC_SWAGGER-UI_ENABLED: "true"
     FLIPT_URL: "https://feature-toggles-dev.hmpps.service.justice.gov.uk"
-    FLIPT_NAMESPACE: "hmpps-electronic-monitoring-crime-matching"
 
   namespace_secrets:
     athena-roles: null

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -18,6 +18,8 @@ generic-service:
     DATASTORE_DATABASE: "acquisitive_crime_test_dbt"
     SPRINGDOC_API-DOCS_ENABLED: "true"
     SPRINGDOC_SWAGGER-UI_ENABLED: "true"
+    FLIPT_URL: "https://feature-toggles-dev.hmpps.service.justice.gov.uk"
+    FLIPT_NAMESPACE: "hmpps-electronic-monitoring-crime-matching"
 
   namespace_secrets:
     athena-roles: null

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -17,7 +17,6 @@ generic-service:
     MFA_REQUIRED: "false"
     DATASTORE_DATABASE: "acquisitive_crime_preprod_dbt"
     FLIPT_URL: "https://feature-toggles-preprod.hmpps.service.justice.gov.uk"
-    FLIPT_NAMESPACE: "hmpps-electronic-monitoring-crime-matching"
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -16,6 +16,8 @@ generic-service:
     ATHENA_WORKGROUP: "443370694497-default"
     MFA_REQUIRED: "false"
     DATASTORE_DATABASE: "acquisitive_crime_preprod_dbt"
+    FLIPT_URL: "https://feature-toggles-preprod.hmpps.service.justice.gov.uk"
+    FLIPT_NAMESPACE: "hmpps-electronic-monitoring-crime-matching"
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -13,6 +13,8 @@ generic-service:
     ATHENA_WORKGROUP: "placeholder"
     MFA_REQUIRED: "false"
     DATASTORE_DATABASE: "placeholder"
+    FLIPT_URL: "https://feature-toggles.hmpps.service.justice.gov.uk"
+    FLIPT_NAMESPACE: "hmpps-electronic-monitoring-crime-matching"
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -14,7 +14,6 @@ generic-service:
     MFA_REQUIRED: "false"
     DATASTORE_DATABASE: "placeholder"
     FLIPT_URL: "https://feature-toggles.hmpps.service.justice.gov.uk"
-    FLIPT_NAMESPACE: "hmpps-electronic-monitoring-crime-matching"
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/config/flipt/FliptConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/config/flipt/FliptConfiguration.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.config.flipt
+
+import io.flipt.client.FliptClient
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.time.Duration
+
+@Configuration
+@EnableConfigurationProperties(FliptProperties::class)
+class FliptConfiguration(
+  private val properties: FliptProperties,
+) {
+  @Bean
+  fun fliptClient() = FliptClient
+    .builder()
+    .namespace(properties.namespace)
+    .url(properties.url)
+    .updateInterval(Duration.ofSeconds(properties.pollingIntervalSeconds))
+    .build()
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/config/flipt/FliptProperties.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/config/flipt/FliptProperties.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.config.flipt
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "flipt")
+data class FliptProperties(
+  val url: String,
+  val namespace: String,
+  val pollingIntervalSeconds: Long = 120,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/config/notify/NotifyConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/config/notify/NotifyConfig.kt
@@ -12,5 +12,5 @@ import uk.gov.service.notify.NotificationClient
 class NotifyConfig(private val properties: NotifyProperties) {
 
   @Bean
-  fun notifyClient(): NotificationClient = NotificationClient(properties.apikey)
+  fun notifyClient(): NotificationClient = NotificationClient(properties.apikey, properties.baseUrl)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/config/notify/NotifyProperties.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/config/notify/NotifyProperties.kt
@@ -5,6 +5,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 @ConfigurationProperties(prefix = "notify")
 data class NotifyProperties(
   val enabled: Boolean,
+  val baseUrl: String,
   val successfulIngestionTemplateId: String,
   val failedIngestionTemplateId: String,
   val partialIngestionTemplateId: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/internal/EmailNotificationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/internal/EmailNotificationService.kt
@@ -34,7 +34,7 @@ class EmailNotificationService(
 
     val emailAddresses = buildList {
       add(ingestionOutcome.emailData.sender)
-      if (featureFlagService.enabled(FeatureFlagService.ENABLE_POLICE_EMAIL_NOTIFICATIONS)) {
+      if (featureFlagService.policeConfirmationEmailsEnabled()) {
         add(ingestionOutcome.emailData.originalSender)
       }
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/internal/EmailNotificationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/internal/EmailNotificationService.kt
@@ -12,6 +12,7 @@ import java.time.LocalDate
 
 @Service
 class EmailNotificationService(
+  private val featureFlagService: FeatureFlagService,
   private val notifyClient: NotificationClient,
   private val properties: NotifyProperties,
 ) {
@@ -31,10 +32,12 @@ class EmailNotificationService(
       recordCount = ingestionOutcome.recordCount,
     )
 
-    val emailAddresses = listOf(
-      ingestionOutcome.emailData.sender,
-      ingestionOutcome.emailData.originalSender,
-    )
+    val emailAddresses = buildList {
+      add(ingestionOutcome.emailData.sender)
+      if (featureFlagService.enabled(FeatureFlagService.ENABLE_POLICE_EMAIL_NOTIFICATIONS)) {
+        add(ingestionOutcome.emailData.originalSender)
+      }
+    }
 
     for (emailAddress in emailAddresses) {
       sendEmail(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/internal/EmailParserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/internal/EmailParserService.kt
@@ -33,11 +33,11 @@ class EmailParserService(
     val attachments = extractCsvAttachment(message)
 
     return EmailData(
-      redirectAddress,
-      originalSender,
-      subject,
-      sentAt,
-      attachments,
+      sender = redirectAddress,
+      originalSender = originalSender,
+      subject = subject,
+      sentAt = sentAt,
+      attachments = attachments,
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/internal/EmailParserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/internal/EmailParserService.kt
@@ -24,16 +24,17 @@ class EmailParserService(
     val message = MimeMessage(session, emailFile)
 
     val subject = message.subject
-    val sender = (message.from?.firstOrNull() as? InternetAddress)?.address!!
+    val originalSender = (message.from?.firstOrNull() as? InternetAddress)?.address!!
     val sentAt = message.sentDate
-    val redirectAddress = message.getHeader("Resent-From", null) ?: throw ValidationException("No redirect email")
+    val redirectHeader = message.getHeader("Resent-From", null) ?: throw ValidationException("No redirect email")
+    val redirectAddress = InternetAddress.parse(redirectHeader).first().address
 
-    validateMetadata(subject, sender, redirectAddress)
+    validateMetadata(subject, originalSender, redirectAddress)
     val attachments = extractCsvAttachment(message)
 
     return EmailData(
-      sender,
       redirectAddress,
+      originalSender,
       subject,
       sentAt,
       attachments,
@@ -43,7 +44,7 @@ class EmailParserService(
   private fun validateMetadata(subject: String, sender: String, redirectAddress: String) {
     if (!subject.contains("Crime Mapping Request", ignoreCase = true)) throw ValidationException("Invalid email subject")
 
-    if (!redirectAddress.contains(properties.mailboxAddress, ignoreCase = true)) throw ValidationException("Invalid redirect email")
+    if (!redirectAddress.equals(properties.mailboxAddress, ignoreCase = true)) throw ValidationException("Invalid redirect email")
 
     if (!properties.validEmails.values.contains(sender.lowercase())) throw ValidationException("Invalid sender email")
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/internal/FeatureFlagService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/internal/FeatureFlagService.kt
@@ -1,0 +1,24 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.service.internal
+
+import io.flipt.client.FliptClient
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+
+@Service
+class FeatureFlagService(
+  private val client: FliptClient,
+) {
+  companion object {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+    const val ENABLE_POLICE_EMAIL_NOTIFICATIONS = "enable-police-email-notifications"
+  }
+
+  fun enabled(key: String) = try {
+    client
+      .evaluateBoolean(key, "entityId", emptyMap())
+      .isEnabled
+  } catch (e: Exception) {
+    logger.warn("Error retrieving feature flag $key, defaulting to false", e)
+    false
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/internal/FeatureFlagService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/internal/FeatureFlagService.kt
@@ -10,15 +10,17 @@ class FeatureFlagService(
 ) {
   companion object {
     private val logger = LoggerFactory.getLogger(this::class.java)
-    const val ENABLE_POLICE_EMAIL_NOTIFICATIONS = "enable-police-email-notifications"
+    const val ENABLE_POLICE_CONFIRMATION_EMAILS = "enable-police-confirmation-emails"
   }
 
-  fun enabled(key: String) = try {
-    client
-      .evaluateBoolean(key, "entityId", emptyMap())
-      .isEnabled
+  fun policeConfirmationEmailsEnabled() = try {
+    enabled(ENABLE_POLICE_CONFIRMATION_EMAILS)
   } catch (e: Exception) {
-    logger.warn("Error retrieving feature flag $key, defaulting to false", e)
+    logger.warn("Error retrieving feature flag $ENABLE_POLICE_CONFIRMATION_EMAILS, defaulting to false", e)
     false
   }
+
+  private fun enabled(key: String): Boolean = client
+    .evaluateBoolean(key, "entityId", emptyMap())
+    .isEnabled
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -28,6 +28,11 @@ aws:
 notify:
   enabled: false
 
+flipt:
+  url: https://feature-toggles-dev.hmpps.service.justice.gov.uk
+  namespace: hmpps-electronic-monitoring-crime-matching
+  polling-interval-in-seconds: 120
+
 spring:
   datasource:
     url: jdbc:postgresql://localhost:5432/postgres?sslmode=prefer

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -77,11 +77,17 @@ services:
 
 notify:
   enabled: true
+  base-url: https://api.notifications.service.gov.uk
   apikey: ${NOTIFY_API_KEY}
   successfulIngestionTemplateId: 4e75981e-ba14-477e-afea-5ec111c7bf11
   failedIngestionTemplateId: 57f34eb4-7fc6-4b2b-806b-f64d7b27a497
   partialIngestionTemplateId: 02a53929-0984-4d55-bb02-94e6f10d31a8
   errorIngestionTemplateId: 0357bd00-d129-423f-8a6f-0e1761cc13f8
+
+flipt:
+  url: ${FLIPT_URL}
+  namespace: ${FLIPT_NAMESPACE}
+  polling-interval-in-seconds: 120
 
 aws:
   region: eu-west-2

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/IntegrationTestBase.kt
@@ -25,10 +25,11 @@ import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.integra
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.integration.wiremock.AwsApiExtension.Companion.awsMockServer
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.integration.wiremock.HmppsAuthApiExtension
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.integration.wiremock.HmppsAuthApiExtension.Companion.hmppsAuth
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.integration.wiremock.NotifyApiExtension
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.repository.caching.CacheEntryRepository
 import uk.gov.justice.hmpps.test.kotlin.auth.JwtAuthorisationHelper
 
-@ExtendWith(HmppsAuthApiExtension::class, AwsApiExtension::class)
+@ExtendWith(HmppsAuthApiExtension::class, AwsApiExtension::class, NotifyApiExtension::class)
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @ActiveProfiles("test")
 @AutoConfigureWebTestClient

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/listener/EmailListenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/listener/EmailListenerTest.kt
@@ -9,9 +9,11 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
 import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.services.s3.S3Client
@@ -30,6 +32,7 @@ import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helper.
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helper.createEmailFileWithMultipleAttachments
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helper.createEmailFileWithoutAttachment
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.integration.wiremock.NotifyApiExtension.Companion.notifyMockServer
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.entity.Crime
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.entity.CrimeBatch
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.entity.CrimeBatchEmail
@@ -46,6 +49,7 @@ import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.reposit
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.repository.crimeBatch.CrimeBatchRepository
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.repository.crimeBatch.CrimeRepository
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.repository.crimeBatch.CrimeVersionRepository
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.service.internal.FeatureFlagService
 import uk.gov.justice.hmpps.sqs.HmppsQueueService
 import uk.gov.justice.hmpps.sqs.MissingQueueException
 import uk.gov.justice.hmpps.sqs.countAllMessagesOnQueue
@@ -92,6 +96,9 @@ class EmailListenerTest : IntegrationTestBase() {
 
   @MockitoSpyBean
   lateinit var crimeBatchEmailAttachmentIngestionErrorRepository: CrimeBatchEmailAttachmentIngestionErrorRepository
+
+  @MockitoBean
+  lateinit var featureFlagService: FeatureFlagService
 
   val emailQueueConfig by lazy {
     hmppsQueueService.findByQueueId("email")
@@ -488,6 +495,54 @@ class EmailListenerTest : IntegrationTestBase() {
 
       // Check that notification to start algo was generated
       assertThat(getNumberOfMessagesCurrentlyOnMatchingNotificationsQueue()).isEqualTo(1)
+    }
+
+    @Test
+    fun `it should send emails to both the original and redirecting address when the police emails feature flag is true`() {
+      val csvContent = listOf(
+        createCsvRow(),
+        createCsvRow(crimeReference = "CRI00000002"),
+      ).joinToString("\n")
+
+      val encoded = Base64.encode(csvContent.toByteArray())
+      val email = createEmailFile(encoded)
+
+      s3Client.putObject(PutObjectRequest.builder().bucket(BUCKET_NAME).key(OBJECT_KEY).build(), RequestBody.fromString(email))
+
+      // Police emails flag set to true
+      whenever(featureFlagService.enabled(FeatureFlagService.ENABLE_POLICE_EMAIL_NOTIFICATIONS)).thenReturn(true)
+
+      sendDomainSqsMessage(getMessage(OBJECT_KEY))
+
+      await().until { getNumberOfMessagesCurrentlyOnQueue() == 0 }
+
+      // Verify Notify Emails
+      notifyMockServer.verifyEmailSentTo("shared-mailbox@email.com", 1)
+      notifyMockServer.verifyEmailSentTo("test@email.com", 1)
+    }
+
+    @Test
+    fun `it should not send an email to the original address when the police emails feature flag is false`() {
+      val csvContent = listOf(
+        createCsvRow(),
+        createCsvRow(crimeReference = "CRI00000002"),
+      ).joinToString("\n")
+
+      val encoded = Base64.encode(csvContent.toByteArray())
+      val email = createEmailFile(encoded)
+
+      s3Client.putObject(PutObjectRequest.builder().bucket(BUCKET_NAME).key(OBJECT_KEY).build(), RequestBody.fromString(email))
+
+      // Police emails flag set to false
+      whenever(featureFlagService.enabled(FeatureFlagService.ENABLE_POLICE_EMAIL_NOTIFICATIONS)).thenReturn(false)
+
+      sendDomainSqsMessage(getMessage(OBJECT_KEY))
+
+      await().until { getNumberOfMessagesCurrentlyOnQueue() == 0 }
+
+      // Verify Notify Emails
+      notifyMockServer.verifyEmailSentTo("shared-mailbox@email.com", 1)
+      notifyMockServer.verifyEmailSentTo("test@email.com", 0)
     }
 
     fun sendDomainSqsMessage(rawMessage: String): CompletableFuture<SendMessageResponse> = emailQueueSqsClient.sendMessage(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/listener/EmailListenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/listener/EmailListenerTest.kt
@@ -510,7 +510,7 @@ class EmailListenerTest : IntegrationTestBase() {
       s3Client.putObject(PutObjectRequest.builder().bucket(BUCKET_NAME).key(OBJECT_KEY).build(), RequestBody.fromString(email))
 
       // Police emails flag set to true
-      whenever(featureFlagService.enabled(FeatureFlagService.ENABLE_POLICE_EMAIL_NOTIFICATIONS)).thenReturn(true)
+      whenever(featureFlagService.policeConfirmationEmailsEnabled()).thenReturn(true)
 
       sendDomainSqsMessage(getMessage(OBJECT_KEY))
 
@@ -534,7 +534,7 @@ class EmailListenerTest : IntegrationTestBase() {
       s3Client.putObject(PutObjectRequest.builder().bucket(BUCKET_NAME).key(OBJECT_KEY).build(), RequestBody.fromString(email))
 
       // Police emails flag set to false
-      whenever(featureFlagService.enabled(FeatureFlagService.ENABLE_POLICE_EMAIL_NOTIFICATIONS)).thenReturn(false)
+      whenever(featureFlagService.policeConfirmationEmailsEnabled()).thenReturn(false)
 
       sendDomainSqsMessage(getMessage(OBJECT_KEY))
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/wiremock/NotifyApiExtension.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/wiremock/NotifyApiExtension.kt
@@ -1,0 +1,30 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.integration.wiremock
+
+import org.junit.jupiter.api.extension.AfterAllCallback
+import org.junit.jupiter.api.extension.BeforeAllCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+
+class NotifyApiExtension :
+  BeforeAllCallback,
+  AfterAllCallback,
+  BeforeEachCallback {
+
+  companion object {
+    @JvmField
+    val notifyMockServer = NotifyMockServer()
+  }
+
+  override fun beforeAll(context: ExtensionContext) {
+    notifyMockServer.start()
+  }
+
+  override fun beforeEach(context: ExtensionContext) {
+    notifyMockServer.resetAll()
+    notifyMockServer.stubSendEmail()
+  }
+
+  override fun afterAll(context: ExtensionContext) {
+    notifyMockServer.stop()
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/wiremock/NotifyMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/wiremock/NotifyMockServer.kt
@@ -1,0 +1,52 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.integration.wiremock
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.equalTo
+import com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath
+import com.github.tomakehurst.wiremock.client.WireMock.post
+import com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+
+class NotifyMockServer : WireMockServer(WIREMOCK_PORT) {
+  companion object {
+    private const val WIREMOCK_PORT = 8092
+  }
+
+  fun stubSendEmail() {
+    stubFor(
+      post(urlEqualTo("/v2/notifications/email"))
+        .willReturn(
+          aResponse()
+            .withStatus(201)
+            .withHeader("Content-Type", "application/json")
+            .withBody(
+              """
+              {
+                "id": "00000000-0000-0000-0000-000000000001",
+                "reference": "test-reference",
+                "content": {
+                  "body": "Test email body",
+                  "from_email": "test@example.com",
+                  "subject": "Test subject"
+                },
+                "template": {
+                  "id": "00000000-0000-0000-0000-000000000002",
+                  "version": 1,
+                  "uri": "https://api.notifications.service.gov.uk/v2/template/test"
+                },
+                "one_click_unsubscribe_url": null,
+                "sanitised_content": null
+              }
+              """.trimIndent(),
+            ),
+        ),
+    )
+  }
+
+  fun verifyEmailSentTo(address: String, count: Int) = verify(
+    count,
+    postRequestedFor(urlEqualTo("/v2/notifications/email"))
+      .withRequestBody(matchingJsonPath("$.email_address", equalTo(address))),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/internal/EmailNotificationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/internal/EmailNotificationServiceTest.kt
@@ -32,6 +32,7 @@ class EmailNotificationServiceTest {
   private lateinit var service: EmailNotificationService
   private lateinit var notifyClient: NotificationClient
   private val notifyProperties: NotifyProperties = mock()
+  private val featureFlagService: FeatureFlagService = mock()
 
   @BeforeEach
   fun setup() {
@@ -39,8 +40,10 @@ class EmailNotificationServiceTest {
     whenever(notifyProperties.failedIngestionTemplateId).thenReturn("failedTemplateId")
     whenever(notifyProperties.partialIngestionTemplateId).thenReturn("partialTemplateId")
     whenever(notifyProperties.errorIngestionTemplateId).thenReturn("errorTemplateId")
+    whenever(featureFlagService.enabled(FeatureFlagService.ENABLE_POLICE_EMAIL_NOTIFICATIONS))
+      .thenReturn(true)
     notifyClient = Mockito.mock(NotificationClient::class.java)
-    service = EmailNotificationService(notifyClient, notifyProperties)
+    service = EmailNotificationService(featureFlagService, notifyClient, notifyProperties)
   }
 
   @Test
@@ -155,7 +158,7 @@ class EmailNotificationServiceTest {
     assertDoesNotThrow { service.sendEmails(ingestionOutcome) }
 
     verify(notifyClient, times(1)).sendEmail("failedTemplateId", "sender", personalisation, "Unknown due to an error")
-    verify(notifyClient, times(1)).sendEmail("failedTemplateId", "sender", personalisation, "Unknown due to an error")
+    verify(notifyClient, times(1)).sendEmail("failedTemplateId", "originalSender", personalisation, "Unknown due to an error")
   }
 
   @Test
@@ -268,5 +271,41 @@ class EmailNotificationServiceTest {
       verify(notifyClient, times(1)).sendEmail(eq("errorTemplateId"), eq("sender"), any(), eq(batchId))
       verify(notifyClient, times(1)).sendEmail(eq("errorTemplateId"), eq("originalSender"), any(), eq(batchId))
     }
+  }
+
+  @Test
+  fun `it should not send an email to the original sender when the send police email flag is false`() {
+    whenever(notifyProperties.enabled).thenReturn(true)
+    whenever(featureFlagService.enabled(FeatureFlagService.ENABLE_POLICE_EMAIL_NOTIFICATIONS)).thenReturn(false)
+
+    val emailData = EmailData(
+      sender = "sender",
+      originalSender = "originalSender",
+      subject = "subject",
+      sentAt = Date.from(Instant.now()),
+      attachments = emptyList(),
+    )
+
+    val personalisation = mapOf(
+      "fileName" to "Invalid File",
+      "ingestionDate" to LocalDate.now().toString(),
+      "batchId" to "Unknown due to an error",
+      "policeForce" to "Unknown due to an error",
+      "errorSummary" to CrimeBatchEmailIngestionErrorType.INVALID_ATTACHMENT.message,
+      "totalCount" to 0,
+    )
+
+    val ingestionOutcome = EmailIngestionOutcome(
+      batchId = "Unknown due to an error",
+      policeForce = "Unknown due to an error",
+      emailData = emailData,
+      errorType = CrimeBatchEmailIngestionErrorType.INVALID_ATTACHMENT,
+      ingestionStatus = IngestionStatus.FAILED,
+    )
+
+    assertDoesNotThrow { service.sendEmails(ingestionOutcome) }
+
+    verify(notifyClient, times(1)).sendEmail("failedTemplateId", "sender", personalisation, "Unknown due to an error")
+    verify(notifyClient, times(0)).sendEmail("failedTemplateId", "originalSender", personalisation, "Unknown due to an error")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/internal/EmailNotificationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/internal/EmailNotificationServiceTest.kt
@@ -40,8 +40,7 @@ class EmailNotificationServiceTest {
     whenever(notifyProperties.failedIngestionTemplateId).thenReturn("failedTemplateId")
     whenever(notifyProperties.partialIngestionTemplateId).thenReturn("partialTemplateId")
     whenever(notifyProperties.errorIngestionTemplateId).thenReturn("errorTemplateId")
-    whenever(featureFlagService.enabled(FeatureFlagService.ENABLE_POLICE_EMAIL_NOTIFICATIONS))
-      .thenReturn(true)
+    whenever(featureFlagService.policeConfirmationEmailsEnabled()).thenReturn(true)
     notifyClient = Mockito.mock(NotificationClient::class.java)
     service = EmailNotificationService(featureFlagService, notifyClient, notifyProperties)
   }
@@ -276,7 +275,7 @@ class EmailNotificationServiceTest {
   @Test
   fun `it should not send an email to the original sender when the send police email flag is false`() {
     whenever(notifyProperties.enabled).thenReturn(true)
-    whenever(featureFlagService.enabled(FeatureFlagService.ENABLE_POLICE_EMAIL_NOTIFICATIONS)).thenReturn(false)
+    whenever(featureFlagService.policeConfirmationEmailsEnabled()).thenReturn(false)
 
     val emailData = EmailData(
       sender = "sender",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/internal/FeatureFlagServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/internal/FeatureFlagServiceTest.kt
@@ -1,0 +1,48 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.service.internal
+
+import io.flipt.client.FliptClient
+import io.flipt.client.FliptException
+import io.flipt.client.models.BooleanEvaluationResponse
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.whenever
+
+class FeatureFlagServiceTest {
+  private lateinit var featureFlagService: FeatureFlagService
+  private val fliptClient: FliptClient = mock()
+  private val response: BooleanEvaluationResponse = mock()
+
+  @BeforeEach
+  fun setup() {
+    featureFlagService = FeatureFlagService(fliptClient)
+  }
+
+  @Test
+  fun `it should return true when the feature flag is enabled`() {
+    whenever(fliptClient.evaluateBoolean(FeatureFlagService.ENABLE_POLICE_EMAIL_NOTIFICATIONS, "entityId", emptyMap()))
+      .thenReturn(response)
+    whenever(response.isEnabled).thenReturn(true)
+
+    assertTrue(featureFlagService.enabled(FeatureFlagService.ENABLE_POLICE_EMAIL_NOTIFICATIONS))
+  }
+
+  @Test
+  fun `it should return false when the feature flag is disabled`() {
+    whenever(fliptClient.evaluateBoolean(FeatureFlagService.ENABLE_POLICE_EMAIL_NOTIFICATIONS, "entityId", emptyMap()))
+      .thenReturn(response)
+    whenever(response.isEnabled).thenReturn(false)
+
+    assertFalse(featureFlagService.enabled(FeatureFlagService.ENABLE_POLICE_EMAIL_NOTIFICATIONS))
+  }
+
+  @Test
+  fun `it should return false when the flag can't be retrieved`() {
+    whenever(fliptClient.evaluateBoolean(FeatureFlagService.ENABLE_POLICE_EMAIL_NOTIFICATIONS, "entityId", emptyMap()))
+      .thenThrow(FliptException::class.java)
+
+    assertFalse(featureFlagService.enabled(FeatureFlagService.ENABLE_POLICE_EMAIL_NOTIFICATIONS))
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/internal/FeatureFlagServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/service/internal/FeatureFlagServiceTest.kt
@@ -22,27 +22,27 @@ class FeatureFlagServiceTest {
 
   @Test
   fun `it should return true when the feature flag is enabled`() {
-    whenever(fliptClient.evaluateBoolean(FeatureFlagService.ENABLE_POLICE_EMAIL_NOTIFICATIONS, "entityId", emptyMap()))
+    whenever(fliptClient.evaluateBoolean(FeatureFlagService.ENABLE_POLICE_CONFIRMATION_EMAILS, "entityId", emptyMap()))
       .thenReturn(response)
     whenever(response.isEnabled).thenReturn(true)
 
-    assertTrue(featureFlagService.enabled(FeatureFlagService.ENABLE_POLICE_EMAIL_NOTIFICATIONS))
+    assertTrue(featureFlagService.policeConfirmationEmailsEnabled())
   }
 
   @Test
   fun `it should return false when the feature flag is disabled`() {
-    whenever(fliptClient.evaluateBoolean(FeatureFlagService.ENABLE_POLICE_EMAIL_NOTIFICATIONS, "entityId", emptyMap()))
+    whenever(fliptClient.evaluateBoolean(FeatureFlagService.ENABLE_POLICE_CONFIRMATION_EMAILS, "entityId", emptyMap()))
       .thenReturn(response)
     whenever(response.isEnabled).thenReturn(false)
 
-    assertFalse(featureFlagService.enabled(FeatureFlagService.ENABLE_POLICE_EMAIL_NOTIFICATIONS))
+    assertFalse(featureFlagService.policeConfirmationEmailsEnabled())
   }
 
   @Test
   fun `it should return false when the flag can't be retrieved`() {
-    whenever(fliptClient.evaluateBoolean(FeatureFlagService.ENABLE_POLICE_EMAIL_NOTIFICATIONS, "entityId", emptyMap()))
+    whenever(fliptClient.evaluateBoolean(FeatureFlagService.ENABLE_POLICE_CONFIRMATION_EMAILS, "entityId", emptyMap()))
       .thenThrow(FliptException::class.java)
 
-    assertFalse(featureFlagService.enabled(FeatureFlagService.ENABLE_POLICE_EMAIL_NOTIFICATIONS))
+    assertFalse(featureFlagService.policeConfirmationEmailsEnabled())
   }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -62,12 +62,18 @@ datastore:
   workgroup: test-workgroup
 
 notify:
-  enabled: false
-  apikey: test-key
+  enabled: true
+  base-url: http://localhost:8092
+  apikey: 0123456789abcdef0123456789abcdef
   successfulIngestionTemplateId: c3df947e-2473-11f1-8dc8-2246b06f42bf
   failedIngestionTemplateId: ccd9f27c-2473-11f1-9dfb-2246b06f42bf
   partialIngestionTemplateId: def0238c-2473-11f1-8c78-2246b06f42bf
   errorIngestionTemplateId: eat1238d-2473-11f1-8c78-2246b06f42bf
+
+flipt:
+  url: http://localhost:8092
+  namespace: hmpps-electronic-monitoring-crime-matching
+  polling-interval-in-seconds: 120
   
 email-ingestion:
   valid-emails:


### PR DESCRIPTION
Setting up a feature flag service using flipt integration for controlling police email notification functionality.

### Changes
- Added Flipt integration for feature flag functionality.
- Added initial feature flag for sending police email notifcations.
- Added Notify verification to integration tests to verify emails sent.
- Updated parsing of redirect address to remove unwanted `<` & `>` characters, this was previously resulting in an invalid address when attempting to send email notifications to the mailbox.