### PR TITLE
ACR-1008 - Handling datastore sentinel value for device deactivation date

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/helpers/NullIfSentinelDate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/helpers/NullIfSentinelDate.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers
+
+private const val DEVICE_DEACTIVATION_DATE_SENTINEL = "2999-12-12 23:59:59.000"
+
+fun nullIfSentinelDate(value: String?): String? = value
+  ?.takeUnless { it == DEVICE_DEACTIVATION_DATE_SENTINEL }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/deviceActivation/DeviceActivationRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/deviceActivation/DeviceActivationRepository.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.reposi
 
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.client.EmDatastoreClient
-import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.SimpleResultSetExtractor
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.entity.DeviceActivation
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.repository.AthenaRepository
 import java.util.Optional
@@ -12,7 +11,7 @@ class DeviceActivationRepository(
   athenaClient: EmDatastoreClient,
 ) : AthenaRepository<DeviceActivation>(athenaClient) {
 
-  override val resultSetExtractor = SimpleResultSetExtractor(DeviceActivation::class.java)
+  override val resultSetExtractor = DeviceActivationResultSetExtractor()
 
   fun findById(id: Long): Optional<DeviceActivation> = Optional.ofNullable(
     this.executeQuery(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/deviceActivation/DeviceActivationResultSetExtractor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/deviceActivation/DeviceActivationResultSetExtractor.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.repository.deviceActivation
+
+import software.amazon.awssdk.services.athena.model.ResultSet
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.AthenaResultSetExtractor
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.formatter
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.nullIfSentinelDate
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.nullableLocalDateTime
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.entity.DeviceActivation
+import java.time.LocalDateTime
+
+class DeviceActivationResultSetExtractor : AthenaResultSetExtractor<DeviceActivation> {
+  override fun extractData(resultSet: ResultSet): List<DeviceActivation> = resultSet
+    .rows()
+    .drop(1)
+    .map { row ->
+      val fields = row.data().map { it.varCharValue() }
+
+      DeviceActivation(
+        deviceActivationId = fields[0].toLong(),
+        deviceId = fields[1].toLong(),
+        uniqueDeviceWearerId = fields[2],
+        deviceActivationDate = LocalDateTime.parse(fields[3], formatter),
+        deviceDeactivationDate = nullableLocalDateTime(nullIfSentinelDate(fields[4])),
+      )
+    }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/person/PersonResultSetExtractor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/person/PersonResultSetExtractor.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.reposi
 import software.amazon.awssdk.services.athena.model.ResultSet
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.AthenaResultSetExtractor
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.formatter
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.nullIfSentinelDate
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.nullableLocalDateTime
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.entity.DeviceActivation
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.entity.Person
@@ -37,7 +38,7 @@ class PersonResultSetExtractor : AthenaResultSetExtractor<Person> {
           deviceName = "",
           uniqueDeviceWearerId = row[0],
           deviceActivationDate = LocalDateTime.parse(row[12], formatter),
-          deviceDeactivationDate = nullableLocalDateTime(row[13]),
+          deviceDeactivationDate = nullableLocalDateTime(nullIfSentinelDate(row[13])),
           orderStart = "",
           orderEnd = "",
         )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/resource/DeviceActivationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/resource/DeviceActivationControllerTest.kt
@@ -151,6 +151,39 @@ class DeviceActivationControllerTest : IntegrationTestBase() {
     }
 
     @Test
+    fun `it should return a null deactivation date if the device activation has the sentinel date value`() {
+      stubQueryExecution(
+        "123",
+        1,
+        "SUCCEEDED",
+        "athenaResponses/device-activation.sentinel-date-value.success.json",
+      )
+
+      val result = webTestClient.get()
+        .uri("/device-activations/1")
+        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__DEVICE_ACTIVATIONS__RO")))
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody<Response<DeviceActivationResponse>>()
+        .returnResult()
+        .responseBody!!
+
+      assertThat(result.data).isEqualTo(
+        DeviceActivationResponse(
+          deviceActivationId = 12345,
+          deviceId = 54321,
+          deviceName = "",
+          personId = "98765",
+          deviceActivationDate = "2023-05-18T00:00",
+          deviceDeactivationDate = null,
+          orderStart = "",
+          orderEnd = "",
+        ),
+      )
+    }
+
+    @Test
     fun `it should use the cached query execution when a duplicate request is made`() {
       stubQueryExecution(
         "123",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/resource/PersonControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/integration/resource/PersonControllerTest.kt
@@ -68,6 +68,53 @@ class PersonControllerTest : IntegrationTestBase() {
     }
 
     @Test
+    fun `it should return persons with a null device deactivation date if the device activation has the sentinel date value`() {
+      stubQueryExecution(
+        "123",
+        1,
+        "SUCCEEDED",
+        "athenaResponses/persons.device-activations-sentinel-date-value.success.json",
+      )
+
+      val result = webTestClient.get()
+        .uri("/persons?name=name")
+        .headers(setAuthorisation(roles = listOf("ROLE_EM_CRIME_MATCHING__CASELOAD__RO")))
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody<PagedResponse<PersonResponse>>()
+        .returnResult()
+        .responseBody!!
+
+      assertThat(result.data).isNotNull()
+      assertThat(result.data).hasSize(1)
+      assertThat(result.data[0].deviceActivations).hasSize(1)
+      assertThat(result.data[0]).isEqualTo(
+        PersonResponse(
+          personId = "1",
+          name = "first_name last_name",
+          nomisId = "nomis_id",
+          pncRef = "pnc_id",
+          dateOfBirth = "2000-05-29",
+          probationPractitioner = "responsible_officer_name",
+          address = "street, city, zip",
+          deviceActivations = listOf(
+            DeviceActivationResponse(
+              deviceActivationId = 54321,
+              deviceId = 12345,
+              deviceName = "",
+              personId = "1",
+              deviceActivationDate = "2023-05-18T00:00",
+              deviceDeactivationDate = null,
+              orderStart = "",
+              orderEnd = "",
+            ),
+          ),
+        ),
+      )
+    }
+
+    @Test
     fun `it should fail with bad request when invalid criteria fields are passed`() {
       webTestClient.get()
         .uri("/persons")

--- a/src/test/resources/__files/athenaResponses/device-activation.sentinel-date-value.success.json
+++ b/src/test/resources/__files/athenaResponses/device-activation.sentinel-date-value.success.json
@@ -1,0 +1,109 @@
+{
+  "ResultSet": {
+    "ResultSetMetadata": {
+      "ColumnInfo": [
+        {
+          "CaseSensitive": false,
+          "CatalogName": "hive",
+          "Label": "device_activation_id",
+          "Name": "device_activation_id",
+          "Nullable": "UNKNOWN",
+          "Precision": 0,
+          "Scale": 0,
+          "SchemaName": "",
+          "TableName": "",
+          "Type": "bigint"
+        },
+        {
+          "CaseSensitive": false,
+          "CatalogName": "hive",
+          "Label": "device_id",
+          "Name": "device_id",
+          "Nullable": "UNKNOWN",
+          "Precision": 2147483647,
+          "Scale": 0,
+          "SchemaName": "",
+          "TableName": "",
+          "Type": "bigint"
+        },
+        {
+          "CaseSensitive": false,
+          "CatalogName": "hive",
+          "Label": "unique_device_wearer_id",
+          "Name": "unique_device_wearer_id",
+          "Nullable": "UNKNOWN",
+          "Precision": 2147483647,
+          "Scale": 0,
+          "SchemaName": "",
+          "TableName": "",
+          "Type": "bigint"
+        },
+        {
+          "CaseSensitive": false,
+          "CatalogName": "hive",
+          "Label": "device_activation_date",
+          "Name": "device_activation_date",
+          "Nullable": "UNKNOWN",
+          "Precision": 0,
+          "Scale": 0,
+          "SchemaName": "",
+          "TableName": "",
+          "Type": "timestamp"
+        },
+        {
+          "CaseSensitive": false,
+          "CatalogName": "hive",
+          "Label": "device_deactivation_date",
+          "Name": "device_deactivation_date",
+          "Nullable": "UNKNOWN",
+          "Precision": 0,
+          "Scale": 0,
+          "SchemaName": "",
+          "TableName": "",
+          "Type": "timestamp"
+        }
+      ]
+    },
+    "Rows": [
+      {
+        "Data": [
+          {
+            "VarCharValue": "device_activation_id"
+          },
+          {
+            "VarCharValue": "device_id"
+          },
+          {
+            "VarCharValue": "unique_device_wearer_id"
+          },
+          {
+            "VarCharValue": "device_activation_date"
+          },
+          {
+            "VarCharValue": "device_deactivation_date"
+          }
+        ]
+      },
+      {
+        "Data": [
+          {
+            "VarCharValue": "12345"
+          },
+          {
+            "VarCharValue": "54321"
+          },
+          {
+            "VarCharValue": "98765"
+          },
+          {
+            "VarCharValue": "2023-05-18 00:00:00.000"
+          },
+          {
+            "VarCharValue": "2999-12-12 23:59:59.000"
+          }
+        ]
+      }
+    ]
+  },
+  "UpdateCount": 0
+}

--- a/src/test/resources/__files/athenaResponses/persons.device-activations-sentinel-date-value.success.json
+++ b/src/test/resources/__files/athenaResponses/persons.device-activations-sentinel-date-value.success.json
@@ -1,0 +1,271 @@
+{
+  "ResultSet": {
+    "ResultSetMetadata": {
+      "ColumnInfo": [
+        {
+          "CaseSensitive": false,
+          "CatalogName": "hive",
+          "Label": "unique_device_wearer_id",
+          "Name": "unique_device_wearer_id",
+          "Nullable": "UNKNOWN",
+          "Precision": 19,
+          "Scale": 0,
+          "SchemaName": "",
+          "TableName": "",
+          "Type": "varchar"
+        },
+        {
+          "CaseSensitive": true,
+          "CatalogName": "hive",
+          "Label": "first_name",
+          "Name": "first_name",
+          "Nullable": "UNKNOWN",
+          "Precision": 19,
+          "Scale": 0,
+          "SchemaName": "",
+          "TableName": "",
+          "Type": "varchar"
+        },
+        {
+          "CaseSensitive": true,
+          "CatalogName": "hive",
+          "Label": "last_name",
+          "Name": "last_name",
+          "Nullable": "UNKNOWN",
+          "Precision": 19,
+          "Scale": 0,
+          "SchemaName": "",
+          "TableName": "",
+          "Type": "varchar"
+        },
+        {
+          "CaseSensitive": false,
+          "CatalogName": "hive",
+          "Label": "nomis_id",
+          "Name": "nomis_id",
+          "Nullable": "UNKNOWN",
+          "Precision": 2147483647,
+          "Scale": 0,
+          "SchemaName": "",
+          "TableName": "",
+          "Type": "bigint"
+        },
+        {
+          "CaseSensitive": false,
+          "CatalogName": "hive",
+          "Label": "pnc_id",
+          "Name": "pnc_id",
+          "Nullable": "UNKNOWN",
+          "Precision": 19,
+          "Scale": 0,
+          "SchemaName": "",
+          "TableName": "",
+          "Type": "varchar"
+        },
+        {
+          "CaseSensitive": false,
+          "CatalogName": "hive",
+          "Label": "date_of_birth",
+          "Name": "date_of_birth",
+          "Nullable": "UNKNOWN",
+          "Precision": 0,
+          "Scale": 0,
+          "SchemaName": "",
+          "TableName": "",
+          "Type": "date"
+        },
+        {
+          "CaseSensitive": false,
+          "CatalogName": "hive",
+          "Label": "responsible_officer_name",
+          "Name": "responsible_officer_name",
+          "Nullable": "UNKNOWN",
+          "Precision": 19,
+          "Scale": 0,
+          "SchemaName": "",
+          "TableName": "",
+          "Type": "varchar"
+        },
+        {
+          "CaseSensitive": true,
+          "CatalogName": "hive",
+          "Label": "postcode",
+          "Name": "postcode",
+          "Nullable": "UNKNOWN",
+          "Precision": 0,
+          "Scale": 0,
+          "SchemaName": "",
+          "TableName": "",
+          "Type": "varchar"
+        },
+        {
+          "CaseSensitive": false,
+          "CatalogName": "hive",
+          "Label": "city_or_town",
+          "Name": "city_or_town",
+          "Nullable": "UNKNOWN",
+          "Precision": 0,
+          "Scale": 0,
+          "SchemaName": "",
+          "TableName": "",
+          "Type": "varchar"
+        },
+        {
+          "CaseSensitive": false,
+          "CatalogName": "hive",
+          "Label": "house_number_and_street_name",
+          "Name": "house_number_and_street_name",
+          "Nullable": "UNKNOWN",
+          "Precision": 0,
+          "Scale": 0,
+          "SchemaName": "",
+          "TableName": "",
+          "Type": "varchar"
+        },
+        {
+          "CaseSensitive": false,
+          "CatalogName": "hive",
+          "Label": "device_id",
+          "Name": "device_id",
+          "Nullable": "UNKNOWN",
+          "Precision": 2147483647,
+          "Scale": 0,
+          "SchemaName": "",
+          "TableName": "",
+          "Type": "bigint"
+        },
+        {
+          "CaseSensitive": false,
+          "CatalogName": "hive",
+          "Label": "device_activation_id",
+          "Name": "device_activation_id",
+          "Nullable": "UNKNOWN",
+          "Precision": 0,
+          "Scale": 0,
+          "SchemaName": "",
+          "TableName": "",
+          "Type": "bigint"
+        },
+        {
+          "CaseSensitive": false,
+          "CatalogName": "hive",
+          "Label": "device_activation_date",
+          "Name": "device_activation_date",
+          "Nullable": "UNKNOWN",
+          "Precision": 0,
+          "Scale": 0,
+          "SchemaName": "",
+          "TableName": "",
+          "Type": "timestamp"
+        },
+        {
+          "CaseSensitive": false,
+          "CatalogName": "hive",
+          "Label": "device_deactivation_date",
+          "Name": "device_deactivation_date",
+          "Nullable": "UNKNOWN",
+          "Precision": 0,
+          "Scale": 0,
+          "SchemaName": "",
+          "TableName": "",
+          "Type": "timestamp"
+        }
+      ]
+    },
+    "Rows": [
+      {
+        "Data": [
+          {
+            "VarCharValue": "unique_device_wearer_id"
+          },
+          {
+            "VarCharValue": "first_name"
+          },
+          {
+            "VarCharValue": "last_name"
+          },
+          {
+            "VarCharValue": "nomis_id"
+          },
+          {
+            "VarCharValue": "pnc_id"
+          },
+          {
+            "VarCharValue": "date_of_birth"
+          },
+          {
+            "VarCharValue": "responsible_officer_name"
+          },
+          {
+            "VarCharValue": "postcode"
+          },
+          {
+            "VarCharValue": "city_or_town"
+          },
+          {
+            "VarCharValue": "house_number_and_street_name"
+          },
+          {
+            "VarCharValue": "device_id"
+          },
+          {
+            "VarCharValue": "device_activation_id"
+          },
+          {
+            "VarCharValue": "device_activation_date"
+          },
+          {
+            "VarCharValue": "device_deactivation_date"
+          }
+        ]
+      },
+      {
+        "Data": [
+          {
+            "VarCharValue": "1"
+          },
+          {
+            "VarCharValue": "first_name"
+          },
+          {
+            "VarCharValue": "last_name"
+          },
+          {
+            "VarCharValue": "nomis_id"
+          },
+          {
+            "VarCharValue": "pnc_id"
+          },
+          {
+            "VarCharValue": "2000-05-29"
+          },
+          {
+            "VarCharValue": "responsible_officer_name"
+          },
+          {
+            "VarCharValue": "zip"
+          },
+          {
+            "VarCharValue": "city"
+          },
+          {
+            "VarCharValue": "street"
+          },
+          {
+            "VarCharValue": "12345"
+          },
+          {
+            "VarCharValue": "54321"
+          },
+          {
+            "VarCharValue": "2023-05-18 00:00:00.000"
+          },
+          {
+            "VarCharValue": "2999-12-12 23:59:59.000"
+          }
+        ]
+      }
+    ]
+  },
+  "UpdateCount": 0
+}


### PR DESCRIPTION
This PR is aiming to resolve the bug [ACR-1008](https://dsdmoj.atlassian.net/browse/ACR-1008) where active device activations have the date value `12/12/2999 23:59` in preprod and prod.

### Changes
- PersonResultSetExtractor updated to include sentinel date check
- DeviceActivationresultSetExtractor added and includes sentinel date check

[ACR-1008]: https://dsdmoj.atlassian.net/browse/ACR-1008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ