### PR TITLE
Update get persons queries to order by device activation date

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/helpers/querybuilders/Ordering.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/helpers/querybuilders/Ordering.kt
@@ -1,0 +1,17 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders
+
+class Ordering {
+  private val terms = mutableListOf<OrderingTerm>()
+
+  val Column<*>.asc: Unit
+    get() {
+      terms += OrderingTerm(this, SortDirection.ASC)
+    }
+
+  val Column<*>.desc: Unit
+    get() {
+      terms += OrderingTerm(this, SortDirection.DESC)
+    }
+
+  override fun toString(): String = terms.joinToString(", ")
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/helpers/querybuilders/OrderingTerm.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/helpers/querybuilders/OrderingTerm.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders
+
+class OrderingTerm(val column: Column<*>, val direction: SortDirection) {
+  override fun toString(): String = "$column $direction"
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/helpers/querybuilders/Query.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/helpers/querybuilders/Query.kt
@@ -5,6 +5,7 @@ import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.a
 
 class Query(val selectStatement: SelectStatement) {
   private var condition: Condition? = null
+  private var ordering: Ordering? = null
 
   fun prepare(): AthenaQuery {
     val builder = StringBuilder()
@@ -16,6 +17,11 @@ class Query(val selectStatement: SelectStatement) {
       ?.takeIf { it.isNotBlank() }
       ?.let { builder.append(" WHERE ").append(it) }
 
+    ordering
+      ?.toString()
+      ?.takeIf { it.isNotBlank() }
+      ?.let { builder.append(" ORDER BY ").append(it) }
+
     return AthenaQuery(
       queryString = builder.toString(),
       parameters = (condition?.parameters() ?: emptyList()),
@@ -24,6 +30,11 @@ class Query(val selectStatement: SelectStatement) {
 
   fun where(block: Condition.() -> Unit): Query {
     condition = And().apply(block)
+    return this
+  }
+
+  fun orderBy(block: Ordering.() -> Unit): Query {
+    ordering = Ordering().apply(block)
     return this
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/helpers/querybuilders/SortDirection.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/helpers/querybuilders/SortDirection.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders
+
+enum class SortDirection {
+  ASC,
+  DESC,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/person/GetPersonsQueryBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/person/GetPersonsQueryBuilder.kt
@@ -43,5 +43,8 @@ class GetPersonsQueryBuilder(private val personsQueryCriteria: PersonsQueryCrite
         DeviceActivation.deviceId eq it
       }
     }
+    .orderBy {
+      DeviceActivation.deviceActivationDate.desc
+    }
     .prepare()
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/fixtures/queries/AthenaQueries.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/fixtures/queries/AthenaQueries.kt
@@ -55,6 +55,7 @@ object AthenaQueries {
     INNER JOIN 
       device_activations ON caseload.mdss_person_id = device_activations.person_id 
     WHERE ( caseload.first_name LIKE ? OR caseload.last_name LIKE ? )
+    ORDER BY device_activations.device_activation_date DESC
   """.trimIndent().replace("\\s+".toRegex(), " ")
 
   val SelectPersonsByNomisIdLike = """
@@ -78,6 +79,7 @@ object AthenaQueries {
     INNER JOIN 
       device_activations ON caseload.mdss_person_id = device_activations.person_id 
     WHERE caseload.nomis_id LIKE ?
+    ORDER BY device_activations.device_activation_date DESC
   """.trimIndent().replace("\\s+".toRegex(), " ")
 
   val SelectPersonsByDeviceIdLike = """
@@ -101,6 +103,7 @@ object AthenaQueries {
     INNER JOIN 
       device_activations ON caseload.mdss_person_id = device_activations.person_id 
     WHERE device_activations.device_id = ?
+    ORDER BY device_activations.device_activation_date DESC
   """.trimIndent().replace("\\s+".toRegex(), " ")
 
   val SelectPositionsByDeviceActivationId = """

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/helper/queryBuilders/QueryBuilderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/helper/queryBuilders/QueryBuilderTest.kt
@@ -218,6 +218,31 @@ class QueryBuilderTest {
     assertThat(query.parameters).isEqualTo(emptyList<String>())
   }
 
+  @Test
+  fun `it should build a query with an order clause`() {
+    val query = TestTable
+      .selectAll()
+      .orderBy {
+        TestTable.testColumn1.asc
+      }
+      .prepare()
+
+    assertThat(query.queryString).isEqualTo("SELECT * FROM test_table ORDER BY test_table.test_column_1 ASC")
+  }
+
+  @Test
+  fun `it should build a query with multiple order clauses`() {
+    val query = TestTable
+      .selectAll()
+      .orderBy {
+        TestTable.testColumn1.asc
+        TestTable.testColumn2.desc
+      }
+      .prepare()
+
+    assertThat(query.queryString).isEqualTo("SELECT * FROM test_table ORDER BY test_table.test_column_1 ASC, test_table.test_column_2 DESC")
+  }
+
   companion object {
     @JvmStatic
     fun data() = listOf(


### PR DESCRIPTION
Users would like to see the most recent device activation first. My assumption is the device activation with the most recent activation date is always the most recent device activation (i.e. ignoring the deactivation date).

## Changes
- Update the query builder to support an `ORDER BY` clause
- Update the `GetPersonsQueryBuilder` to order by `device_activation_date`