### PR TITLE
Use the current dates caseload in all queries

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/helpers/querybuilders/CastColumn.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/helpers/querybuilders/CastColumn.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders
+
+class CastColumn<T>(
+  private val column: Column<*>,
+  private val type: SqlType,
+) : Column<T>(column.table, column.name) {
+  override fun toString(): String = "CAST($column AS $type)"
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/helpers/querybuilders/Column.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/helpers/querybuilders/Column.kt
@@ -1,7 +1,9 @@
 package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders
 
-class Column<T>(val table: Table, val name: String) : Expression() {
+open class Column<T>(val table: Table, val name: String) : Expression() {
   override fun parameters() = emptyList<String>()
 
   override fun toString(): String = "${table.ref()}.$name"
 }
+
+fun <T> Column<*>.cast(type: SqlType): CastColumn<T> = CastColumn(this, type)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/helpers/querybuilders/Column.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/helpers/querybuilders/Column.kt
@@ -5,5 +5,3 @@ open class Column<T>(val table: Table, val name: String) : Expression() {
 
   override fun toString(): String = "${table.ref()}.$name"
 }
-
-fun <T> Column<*>.cast(type: SqlType): CastColumn<T> = CastColumn(this, type)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/helpers/querybuilders/ColumnExtensions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/helpers/querybuilders/ColumnExtensions.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders
+
+object ColumnExtensions {
+  fun <T> Column<T>.cast(type: SqlType): CastColumn<T> = CastColumn(this, type)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/helpers/querybuilders/SqlType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/helpers/querybuilders/SqlType.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders
+
+enum class SqlType {
+  Date,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/helpers/querybuilders/Table.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/helpers/querybuilders/Table.kt
@@ -17,6 +17,7 @@ open class Table(val name: String) : ColumnSet() {
 
   fun date(name: String): Column<ZonedDateTime> = registerColumn(name)
 
+  // N.B. The Column type acts as a comparison-type constraint rather than the SQL column type
   private fun <T> registerColumn(name: String): Column<T> = Column<T>(this, name).also { _columns.add(it) }
 
   override fun toString() = name

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/helpers/querybuilders/expressions/CurrentDate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/helpers/querybuilders/expressions/CurrentDate.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helper
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.Expression
 
 class CurrentDate : Expression() {
-  override fun parameters() = listOf<String>()
+  override fun parameters() = emptyList<String>()
 
   override fun toString() = "current_date"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/helpers/querybuilders/expressions/CurrentDate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/helpers/querybuilders/expressions/CurrentDate.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.expressions
+
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.Expression
+
+class CurrentDate : Expression() {
+  override fun parameters() = listOf<String>()
+
+  override fun toString() = "current_date"
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/model/athena/Person.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/model/athena/Person.kt
@@ -14,4 +14,5 @@ object Person : Table(name = "caseload") {
   val postcode = varchar("postcode")
   val cityOrTown = varchar("city_or_town")
   val street = varchar("house_number_and_street_name")
+  val groupedDate = date("grouped_date")
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/deviceActivation/GetDeviceActivationByIdQueryBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/deviceActivation/GetDeviceActivationByIdQueryBuilder.kt
@@ -1,9 +1,13 @@
 package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.repository.deviceActivation
 
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.JoinType
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.SqlType
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.cast
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.expressions.CurrentDate
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.athena.AthenaQuery
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.athena.DeviceActivation
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.athena.Person
+import java.time.ZonedDateTime
 
 class GetDeviceActivationByIdQueryBuilder(private val id: Long) {
   fun build(): AthenaQuery = DeviceActivation
@@ -19,6 +23,8 @@ class GetDeviceActivationByIdQueryBuilder(private val id: Long) {
     )
     .where {
       DeviceActivation.deviceActivationId eq id
+
+      Person.groupedDate.cast<ZonedDateTime>(SqlType.Date) eq CurrentDate()
     }
     .prepare()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/deviceActivation/GetDeviceActivationByIdQueryBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/deviceActivation/GetDeviceActivationByIdQueryBuilder.kt
@@ -1,13 +1,12 @@
 package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.repository.deviceActivation
 
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.ColumnExtensions.cast
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.JoinType
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.SqlType
-import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.cast
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.expressions.CurrentDate
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.athena.AthenaQuery
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.athena.DeviceActivation
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.athena.Person
-import java.time.ZonedDateTime
 
 class GetDeviceActivationByIdQueryBuilder(private val id: Long) {
   fun build(): AthenaQuery = DeviceActivation
@@ -24,7 +23,7 @@ class GetDeviceActivationByIdQueryBuilder(private val id: Long) {
     .where {
       DeviceActivation.deviceActivationId eq id
 
-      Person.groupedDate.cast<ZonedDateTime>(SqlType.Date) eq CurrentDate()
+      Person.groupedDate.cast(SqlType.Date) eq CurrentDate()
     }
     .prepare()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/person/GetPersonByIdQueryBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/person/GetPersonByIdQueryBuilder.kt
@@ -1,7 +1,11 @@
 package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.repository.person
 
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.SqlType
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.cast
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.expressions.CurrentDate
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.athena.AthenaQuery
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.athena.Person
+import java.time.ZonedDateTime
 
 class GetPersonByIdQueryBuilder(private val id: String) {
   fun build(): AthenaQuery = Person
@@ -19,6 +23,8 @@ class GetPersonByIdQueryBuilder(private val id: String) {
     )
     .where {
       Person.deviceWearerId eq id
+
+      Person.groupedDate.cast<ZonedDateTime>(SqlType.Date) eq CurrentDate()
     }
     .prepare()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/person/GetPersonByIdQueryBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/person/GetPersonByIdQueryBuilder.kt
@@ -1,11 +1,10 @@
 package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.repository.person
 
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.ColumnExtensions.cast
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.SqlType
-import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.cast
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.expressions.CurrentDate
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.athena.AthenaQuery
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.athena.Person
-import java.time.ZonedDateTime
 
 class GetPersonByIdQueryBuilder(private val id: String) {
   fun build(): AthenaQuery = Person
@@ -24,7 +23,7 @@ class GetPersonByIdQueryBuilder(private val id: String) {
     .where {
       Person.deviceWearerId eq id
 
-      Person.groupedDate.cast<ZonedDateTime>(SqlType.Date) eq CurrentDate()
+      Person.groupedDate.cast(SqlType.Date) eq CurrentDate()
     }
     .prepare()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/person/GetPersonsQueryBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/person/GetPersonsQueryBuilder.kt
@@ -2,9 +2,13 @@ package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.reposi
 
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.dto.PersonsQueryCriteria
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.JoinType
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.SqlType
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.cast
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.expressions.CurrentDate
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.athena.AthenaQuery
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.athena.DeviceActivation
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.athena.Person
+import java.time.ZonedDateTime
 
 class GetPersonsQueryBuilder(private val personsQueryCriteria: PersonsQueryCriteria) {
   fun build(): AthenaQuery = Person
@@ -42,6 +46,8 @@ class GetPersonsQueryBuilder(private val personsQueryCriteria: PersonsQueryCrite
       personsQueryCriteria.deviceId?.let {
         DeviceActivation.deviceId eq it
       }
+
+      Person.groupedDate.cast<ZonedDateTime>(SqlType.Date) eq CurrentDate()
     }
     .orderBy {
       DeviceActivation.deviceActivationDate.desc

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/person/GetPersonsQueryBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/person/GetPersonsQueryBuilder.kt
@@ -1,14 +1,13 @@
 package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.repository.person
 
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.dto.PersonsQueryCriteria
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.ColumnExtensions.cast
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.JoinType
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.SqlType
-import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.cast
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.expressions.CurrentDate
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.athena.AthenaQuery
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.athena.DeviceActivation
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.athena.Person
-import java.time.ZonedDateTime
 
 class GetPersonsQueryBuilder(private val personsQueryCriteria: PersonsQueryCriteria) {
   fun build(): AthenaQuery = Person
@@ -47,7 +46,7 @@ class GetPersonsQueryBuilder(private val personsQueryCriteria: PersonsQueryCrite
         DeviceActivation.deviceId eq it
       }
 
-      Person.groupedDate.cast<ZonedDateTime>(SqlType.Date) eq CurrentDate()
+      Person.groupedDate.cast(SqlType.Date) eq CurrentDate()
     }
     .orderBy {
       DeviceActivation.deviceActivationDate.desc

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/fixtures/queries/AthenaQueries.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/fixtures/queries/AthenaQueries.kt
@@ -12,8 +12,10 @@ object AthenaQueries {
       device_activations
     INNER JOIN 
       caseload ON device_activations.person_id = caseload.mdss_person_id
-    WHERE 
-      device_activations.device_activation_id = ?
+    WHERE (
+      device_activations.device_activation_id = ? AND
+      CAST(caseload.grouped_date AS Date) = current_date
+    )
   """.trimIndent().replace("\\s+".toRegex(), " ")
 
   val SelectPersonById = """
@@ -30,31 +32,36 @@ object AthenaQueries {
       caseload.house_number_and_street_name
     FROM 
       caseload
-    WHERE 
-      caseload.unique_device_wearer_id = ?
+    WHERE (
+      caseload.unique_device_wearer_id = ? AND
+      CAST(caseload.grouped_date AS Date) = current_date
+    )
   """.trimIndent().replace("\\s+".toRegex(), " ")
 
   val SelectPersonsByNameLike = """
-    SELECT 
-      caseload.unique_device_wearer_id, 
+    SELECT
+      caseload.unique_device_wearer_id,
       caseload.first_name,
       caseload.last_name,
       caseload.nomis_id,
       caseload.pnc_id,
       caseload.date_of_birth,
       caseload.responsible_officer_name,
-      caseload.postcode, 
-      caseload.city_or_town, 
-      caseload.house_number_and_street_name, 
+      caseload.postcode,
+      caseload.city_or_town,
+      caseload.house_number_and_street_name,
       device_activations.device_id,
-      device_activations.device_activation_id, 
-      device_activations.device_activation_date, 
-      device_activations.device_deactivation_date 
-    FROM 
-      caseload 
-    INNER JOIN 
-      device_activations ON caseload.mdss_person_id = device_activations.person_id 
-    WHERE ( caseload.first_name LIKE ? OR caseload.last_name LIKE ? )
+      device_activations.device_activation_id,
+      device_activations.device_activation_date,
+      device_activations.device_deactivation_date
+    FROM
+      caseload
+    INNER JOIN
+      device_activations ON caseload.mdss_person_id = device_activations.person_id
+    WHERE ( 
+      ( caseload.first_name LIKE ? OR caseload.last_name LIKE ? ) AND
+      CAST(caseload.grouped_date AS Date) = current_date
+    )
     ORDER BY device_activations.device_activation_date DESC
   """.trimIndent().replace("\\s+".toRegex(), " ")
 
@@ -78,7 +85,10 @@ object AthenaQueries {
       caseload 
     INNER JOIN 
       device_activations ON caseload.mdss_person_id = device_activations.person_id 
-    WHERE caseload.nomis_id LIKE ?
+    WHERE  (
+      caseload.nomis_id LIKE ? AND
+      CAST(caseload.grouped_date AS Date) = current_date
+    )
     ORDER BY device_activations.device_activation_date DESC
   """.trimIndent().replace("\\s+".toRegex(), " ")
 
@@ -102,7 +112,10 @@ object AthenaQueries {
       caseload 
     INNER JOIN 
       device_activations ON caseload.mdss_person_id = device_activations.person_id 
-    WHERE device_activations.device_id = ?
+    WHERE (
+      device_activations.device_id = ? AND
+      CAST(caseload.grouped_date AS Date) = current_date
+    )
     ORDER BY device_activations.device_activation_date DESC
   """.trimIndent().replace("\\s+".toRegex(), " ")
 


### PR DESCRIPTION
The caseload table contains the full history of the caseload. This updates all of our queries using the caseload table to use the caseload matching the current date i.e. `WHERE CAST(caseload.grouped_date AS Date) = current_date`

Unfortunately this has a limitation. If the caseload isn't loaded on the current day then we'll get no results. A longer term solution might be to use the most recent `grouped_date` or the last load date `max(__datetime_added)` rather than the `current_date`.

e.g.
```sql
CAST(grouped_date AS DATE) = (
    SELECT MAX(CAST(grouped_date AS DATE))
    FROM caseload
)
```

This situation could occur if the current caseload is loaded at 4am for example, between 00000 - 0400, all queries will return no results. Similarly, if for some reason the caseload fails for a particular day, then no results would be returned.

Our query builder doesn't support sub queries so this is a temporary fix, to make sure the premise of this change is correct before I work on a longer term approach.