### PR TITLE
Remove grouped date from queries

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/model/athena/Person.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/model/athena/Person.kt
@@ -14,5 +14,4 @@ object Person : Table(name = "caseload") {
   val postcode = varchar("postcode")
   val cityOrTown = varchar("city_or_town")
   val street = varchar("house_number_and_street_name")
-  val groupedDate = date("grouped_date")
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/deviceActivation/GetDeviceActivationByIdQueryBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/deviceActivation/GetDeviceActivationByIdQueryBuilder.kt
@@ -1,9 +1,6 @@
 package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.repository.deviceActivation
 
-import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.ColumnExtensions.cast
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.JoinType
-import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.SqlType
-import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.expressions.CurrentDate
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.athena.AthenaQuery
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.athena.DeviceActivation
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.athena.Person
@@ -23,8 +20,6 @@ class GetDeviceActivationByIdQueryBuilder(private val id: Long) {
     )
     .where {
       DeviceActivation.deviceActivationId eq id
-
-      Person.groupedDate.cast(SqlType.Date) eq CurrentDate()
     }
     .prepare()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/person/GetPersonByIdQueryBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/person/GetPersonByIdQueryBuilder.kt
@@ -1,8 +1,5 @@
 package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.repository.person
 
-import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.ColumnExtensions.cast
-import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.SqlType
-import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.expressions.CurrentDate
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.athena.AthenaQuery
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.athena.Person
 
@@ -22,8 +19,6 @@ class GetPersonByIdQueryBuilder(private val id: String) {
     )
     .where {
       Person.deviceWearerId eq id
-
-      Person.groupedDate.cast(SqlType.Date) eq CurrentDate()
     }
     .prepare()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/person/GetPersonsQueryBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/repository/person/GetPersonsQueryBuilder.kt
@@ -1,10 +1,7 @@
 package uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.repository.person
 
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.dto.PersonsQueryCriteria
-import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.ColumnExtensions.cast
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.JoinType
-import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.SqlType
-import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.expressions.CurrentDate
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.athena.AthenaQuery
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.athena.DeviceActivation
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.model.athena.Person
@@ -46,8 +43,6 @@ class GetPersonsQueryBuilder(private val personsQueryCriteria: PersonsQueryCrite
       personsQueryCriteria.deviceId?.let {
         DeviceActivation.deviceId eq it
       }
-
-      Person.groupedDate.cast(SqlType.Date) eq CurrentDate()
     }
     .orderBy {
       DeviceActivation.deviceActivationDate.desc

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/fixtures/queries/AthenaQueries.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/fixtures/queries/AthenaQueries.kt
@@ -13,10 +13,7 @@ object AthenaQueries {
       device_activations
     INNER JOIN 
       caseload ON device_activations.person_id = caseload.mdss_person_id
-    WHERE (
-      device_activations.device_activation_id = ? AND
-      CAST(caseload.grouped_date AS Date) = current_date
-    )
+    WHERE device_activations.device_activation_id = ?
   """.trimIndent().replace("\\s+".toRegex(), " ")
 
   val SelectPersonById = """
@@ -33,10 +30,7 @@ object AthenaQueries {
       caseload.house_number_and_street_name
     FROM 
       caseload
-    WHERE (
-      caseload.unique_device_wearer_id = ? AND
-      CAST(caseload.grouped_date AS Date) = current_date
-    )
+    WHERE caseload.unique_device_wearer_id = ?
   """.trimIndent().replace("\\s+".toRegex(), " ")
 
   val SelectPersonsByNameLike = """
@@ -60,10 +54,7 @@ object AthenaQueries {
       caseload
     INNER JOIN
       device_activations ON caseload.mdss_person_id = device_activations.person_id
-    WHERE ( 
-      ( caseload.first_name LIKE ? OR caseload.last_name LIKE ? ) AND
-      CAST(caseload.grouped_date AS Date) = current_date
-    )
+    WHERE ( caseload.first_name LIKE ? OR caseload.last_name LIKE ? )
     ORDER BY device_activations.device_activation_date DESC
   """.trimIndent().replace("\\s+".toRegex(), " ")
 
@@ -88,10 +79,7 @@ object AthenaQueries {
       caseload 
     INNER JOIN 
       device_activations ON caseload.mdss_person_id = device_activations.person_id 
-    WHERE  (
-      caseload.nomis_id LIKE ? AND
-      CAST(caseload.grouped_date AS Date) = current_date
-    )
+    WHERE  caseload.nomis_id LIKE ?
     ORDER BY device_activations.device_activation_date DESC
   """.trimIndent().replace("\\s+".toRegex(), " ")
 
@@ -116,10 +104,7 @@ object AthenaQueries {
       caseload 
     INNER JOIN 
       device_activations ON caseload.mdss_person_id = device_activations.person_id 
-    WHERE (
-      device_activations.device_id = ? AND
-      CAST(caseload.grouped_date AS Date) = current_date
-    )
+    WHERE device_activations.device_id = ?
     ORDER BY device_activations.device_activation_date DESC
   """.trimIndent().replace("\\s+".toRegex(), " ")
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/helper/queryBuilders/QueryBuilderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/electronicmonitoringcrimematchingapi/helper/queryBuilders/QueryBuilderTest.kt
@@ -9,8 +9,11 @@ import org.springframework.test.context.ActiveProfiles
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helper.queryBuilders.TestTable.testColumn1
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helper.queryBuilders.TestTable.testColumn2
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helper.queryBuilders.TestTable.testDateColumn
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.ColumnExtensions.cast
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.JoinType
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.SqlType
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.Table
+import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.expressions.CurrentDate
 import uk.gov.justice.digital.hmpps.electronicmonitoringcrimematchingapi.helpers.querybuilders.functions.AthenaFunctions
 import java.time.LocalDateTime
 import java.time.ZoneOffset
@@ -241,6 +244,18 @@ class QueryBuilderTest {
       .prepare()
 
     assertThat(query.queryString).isEqualTo("SELECT * FROM test_table ORDER BY test_table.test_column_1 ASC, test_table.test_column_2 DESC")
+  }
+
+  @Test
+  fun `it should build a query with a cast`() {
+    val query = TestTable
+      .selectAll()
+      .where {
+        TestTable.testColumn1.cast(SqlType.Date) eq CurrentDate()
+      }
+      .prepare()
+
+    assertThat(query.queryString).isEqualTo("SELECT * FROM test_table WHERE CAST(test_table.test_column_1 AS Date) = current_date")
   }
 
   companion object {


### PR DESCRIPTION
`grouped_date` will be removed from caseload in https://github.com/moj-analytical-services/create-a-derived-table/pull/7906 so pre-emptively removing it from our queries.

Left the `CAST()` functionality and added dedicated test for it in the query builder tests.